### PR TITLE
Add admin REST API and migrate web interface to the REST API

### DIFF
--- a/powerauth-push-client/src/main/java/io/getlime/push/client/PushServerClient.java
+++ b/powerauth-push-client/src/main/java/io/getlime/push/client/PushServerClient.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonMappingException;
+import com.google.common.io.BaseEncoding;
 import com.mashape.unirest.http.HttpResponse;
 import com.mashape.unirest.http.ObjectMapper;
 import com.mashape.unirest.http.Unirest;
@@ -488,6 +489,127 @@ public class PushServerClient {
         } catch (UnsupportedEncodingException e) {
             throw new PushServerClientException(new Error("PUSH_SERVER_CLIENT_ERROR", e.getMessage()));
         }
+    }
+
+    /**
+     * Get list of application credentials entities.
+     * @return Application credentials entity list.
+     * @throws PushServerClientException Thrown when communication with Push Server fails.
+     */
+    public ObjectResponse<GetApplicationListResponse> getApplicationList() throws PushServerClientException {
+        final TypeReference<ObjectResponse<GetApplicationListResponse>> typeReference = new TypeReference<ObjectResponse<GetApplicationListResponse>>() {};
+        log("Calling push server to retrieve list of applications - start");
+        final ObjectResponse<GetApplicationListResponse> response = postObjectImpl("/admin/app/list", null, typeReference);
+        log("Calling push server to retrieve list of applications - finish");
+        return response;
+    }
+
+    /**
+     * Get list of applications which are not yet configured in Push Server but exist in PowerAuth server.
+     * @return List of applications which are not configured.
+     * @throws PushServerClientException Thrown when communication with Push Server fails.
+     */
+    public ObjectResponse<GetApplicationListResponse> getUnconfiguredApplicationList() throws PushServerClientException {
+        final TypeReference<ObjectResponse<GetApplicationListResponse>> typeReference = new TypeReference<ObjectResponse<GetApplicationListResponse>>() {};
+        log("Calling push server to retrieve list of unconfigured applications - start");
+        final ObjectResponse<GetApplicationListResponse> response = postObjectImpl("/admin/app/unconfigured/list", null, typeReference);
+        log("Calling push server to retrieve list of unconfigured applications - finish");
+        return response;
+    }
+
+    /**
+     * Get detail for an application credentials entity.
+     * @param id Application credentials entity ID.
+     * @param includeIos Whether to include iOS details.
+     * @param includeAndroid Whether to include Android details.
+     * @return Application credentials entity detail.
+     * @throws PushServerClientException Thrown when communication with Push Server fails.
+     */
+    public ObjectResponse<GetApplicationDetailResponse> getApplicationDetail(Long id, boolean includeIos, boolean includeAndroid) throws PushServerClientException {
+        final TypeReference<ObjectResponse<GetApplicationDetailResponse>> typeReference = new TypeReference<ObjectResponse<GetApplicationDetailResponse>>() {};
+        GetApplicationDetailRequest request = new GetApplicationDetailRequest(id, includeIos, includeAndroid);
+        log("Calling push server to retrieve application detail, ID: {0} - start", new String[] { String.valueOf(id) });
+        final ObjectResponse<GetApplicationDetailResponse> response = postObjectImpl("/admin/app/detail", new ObjectRequest<>(request), typeReference);
+        log("Calling push server to retrieve application detail, ID: {0} - finish", new String[] { String.valueOf(id) });
+        return response;
+    }
+
+    /**
+     * Create application credentials entity.
+     * @param appId PowerAuth application ID.
+     * @return Response with ID of created application credentials entity.
+     * @throws PushServerClientException Thrown when communication with Push Server fails.
+     */
+    public ObjectResponse<CreateApplicationResponse> createApplication(Long appId) throws PushServerClientException {
+        final TypeReference<ObjectResponse<CreateApplicationResponse>> typeReference = new TypeReference<ObjectResponse<CreateApplicationResponse>>() {};
+        final CreateApplicationRequest request = new CreateApplicationRequest(appId);
+        log("Calling push server to create application, app ID: {0} - start", new String[] { String.valueOf(appId) });
+        final ObjectResponse<CreateApplicationResponse> response = postObjectImpl("/admin/app/create", new ObjectRequest<>(request), typeReference);
+        log("Calling push server to create application, app ID: {0} - finish", new String[] { String.valueOf(appId) });
+        return response;
+    }
+
+    /**
+     * Update iOS details for an application credentials entity.
+     * @param id ID of application credentials entity.
+     * @param bundle The iOS bundle record.
+     * @param keyId The iOS key record.
+     * @param teamId The iOS team ID record.
+     * @param privateKey The iOS private key bytes.
+     * @return Response from server.
+     * @throws PushServerClientException Thrown when communication with Push Server fails.
+     */
+    public Response updateIos(Long id, String bundle, String keyId, String teamId, byte[] privateKey) throws PushServerClientException {
+        final String privateKeyBase64 = BaseEncoding.base64().encode(privateKey);
+        final UpdateIosRequest request = new UpdateIosRequest(id, bundle, keyId, teamId, privateKeyBase64);
+        log("Calling push server to update iOS, ID: {0} - start", new String[] { String.valueOf(id) });
+        final Response response = postObjectImpl("/admin/app/ios/update", new ObjectRequest<>(request));
+        log("Calling push server to update iOS, ID: {0} - finish", new String[] { String.valueOf(id) });
+        return response;
+    }
+
+    /**
+     * Remove iOS record from an application credentials entity.
+     * @param id Application credentials entity ID.
+     * @return Response from server.
+     * @throws PushServerClientException Thrown when communication with Push Server fails.
+     */
+    public Response removeIos(Long id) throws PushServerClientException {
+        final RemoveIosRequest request = new RemoveIosRequest(id);
+        log("Calling push server to remove iOS, ID: {0} - start", new String[] { String.valueOf(id) });
+        final Response response = postObjectImpl("/admin/app/ios/remove", new ObjectRequest<>(request));
+        log("Calling push server to remove iOS, ID: {0} - finish", new String[] { String.valueOf(id) });
+        return response;
+    }
+
+    /**
+     * Update Android details for an application credentials entity.
+     * @param id Application credentials entity ID.
+     * @param bundle The Android bundle record.
+     * @param token The Android token (server key).
+     * @return Response from server.
+     * @throws PushServerClientException Thrown when communication with Push Server fails.
+     */
+    public Response updateAndroid(Long id, String bundle, String token) throws PushServerClientException {
+        final UpdateAndroidRequest request = new UpdateAndroidRequest(id, bundle, token);
+        log("Calling push server to update android, ID: {0} - start", new String[] { String.valueOf(id) });
+        final Response response = postObjectImpl("/admin/app/android/update", new ObjectRequest<>(request));
+        log("Calling push server to update android, ID: {0} - finish", new String[] { String.valueOf(id) });
+        return response;
+    }
+
+    /**
+     * Remove Android record from an application credentials entity.
+     * @param id Application credentials entity ID.
+     * @return Response from server.
+     * @throws PushServerClientException Thrown when communication with Push Server fails.
+     */
+    public Response removeAndroid(Long id) throws PushServerClientException {
+        final RemoveAndroidRequest request = new RemoveAndroidRequest(id);
+        log("Calling push server to remove android, ID: {0} - start", new String[] { String.valueOf(id) });
+        final Response response = postObjectImpl("/admin/app/android/remove", new ObjectRequest<>(request));
+        log("Calling push server to remove android, ID: {0} - finish", new String[] { String.valueOf(id) });
+        return response;
     }
 
     // Generic HTTP client methods

--- a/powerauth-push-model/src/main/java/io/getlime/push/model/entity/PushServerApplication.java
+++ b/powerauth-push-model/src/main/java/io/getlime/push/model/entity/PushServerApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Lime - HighTech Solutions s.r.o.
+ * Copyright 2018 Lime - HighTech Solutions s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,8 +14,13 @@
  * limitations under the License.
  */
 
-package io.getlime.push.controller.web.model.view;
+package io.getlime.push.model.entity;
 
+/**
+ * Push server application credentials entity.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
 public class PushServerApplication {
     
     private Long id;
@@ -24,42 +29,82 @@ public class PushServerApplication {
     private Boolean ios;
     private Boolean android;
 
+    /**
+     * Get application credentials entity ID.
+     * @return Application credentials entity ID.
+     */
     public Long getId() {
         return id;
     }
 
+    /**
+     * Set application credentials entity ID.
+     * @param id Application credentials entity ID.
+     */
     public void setId(Long id) {
         this.id = id;
     }
 
+    /**
+     * Get application ID.
+     * @return Application ID.
+     */
     public Long getAppId() {
         return appId;
     }
 
+    /**
+     * Set application ID.
+     * @param appId Application ID.
+     */
     public void setAppId(Long appId) {
         this.appId = appId;
     }
 
+    /**
+     * Get application name.
+     * @return Application name.
+     */
     public String getAppName() {
         return appName;
     }
 
+    /**
+     * Set application name.
+     * @param appName Application name.
+     */
     public void setAppName(String appName) {
         this.appName = appName;
     }
 
+    /**
+     * Get whether iOS is configured.
+     * @return Whether iOS is configured.
+     */
     public Boolean getIos() {
         return ios;
     }
 
+    /**
+     * Set whether iOS is configured.
+     * @param ios Whether iOS is configured.
+     */
     public void setIos(Boolean ios) {
         this.ios = ios;
     }
 
+    /**
+     * Get whether Android is configured.
+     * @return Whether Android is configured.
+     */
     public Boolean getAndroid() {
         return android;
     }
 
+    /**
+     * Set whether Android is configured.
+     * @param android Whether Android is configured.
+     */
     public void setAndroid(Boolean android) {
         this.android = android;
     }

--- a/powerauth-push-model/src/main/java/io/getlime/push/model/request/CreateApplicationRequest.java
+++ b/powerauth-push-model/src/main/java/io/getlime/push/model/request/CreateApplicationRequest.java
@@ -16,7 +16,7 @@
 package io.getlime.push.model.request;
 
 /**
- * Create application request.
+ * Request to create Push Server application credentials entity based on existing PowerAuth server application.
  *
  * @author Roman Strobl, roman.strobl@wultra.com
  */
@@ -31,24 +31,24 @@ public class CreateApplicationRequest {
     }
 
     /**
-     * Constructor with application ID.
-     * @param appId Application ID.
+     * Constructor with PowerAuth server application ID.
+     * @param appId  PowerAuth server application ID.
      */
     public CreateApplicationRequest(Long appId) {
         this.appId = appId;
     }
 
     /**
-     * Get application ID.
-     * @return Application ID.
+     * Get PowerAuth server application ID.
+     * @return PowerAuth server application ID.
      */
     public Long getAppId() {
         return appId;
     }
 
     /**
-     * Set application ID.
-     * @param appId Application ID.
+     * Set PowerAuth server application ID.
+     * @param appId PowerAuth server application ID.
      */
     public void setAppId(Long appId) {
         this.appId = appId;

--- a/powerauth-push-model/src/main/java/io/getlime/push/model/request/CreateApplicationRequest.java
+++ b/powerauth-push-model/src/main/java/io/getlime/push/model/request/CreateApplicationRequest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018 Lime - HighTech Solutions s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getlime.push.model.request;
+
+/**
+ * Create application request.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class CreateApplicationRequest {
+
+    private Long appId;
+
+    /**
+     * Default constructor.
+     */
+    public CreateApplicationRequest() {
+    }
+
+    /**
+     * Constructor with application ID.
+     * @param appId Application ID.
+     */
+    public CreateApplicationRequest(Long appId) {
+        this.appId = appId;
+    }
+
+    /**
+     * Get application ID.
+     * @return Application ID.
+     */
+    public Long getAppId() {
+        return appId;
+    }
+
+    /**
+     * Set application ID.
+     * @param appId Application ID.
+     */
+    public void setAppId(Long appId) {
+        this.appId = appId;
+    }
+}

--- a/powerauth-push-model/src/main/java/io/getlime/push/model/request/GetApplicationDetailRequest.java
+++ b/powerauth-push-model/src/main/java/io/getlime/push/model/request/GetApplicationDetailRequest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2018 Lime - HighTech Solutions s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getlime.push.model.request;
+
+/**
+ * Get application credentials entity detail request.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class GetApplicationDetailRequest {
+
+    private Long id;
+    private boolean includeIos;
+    private boolean includeAndroid;
+
+    /**
+     * Default constructor.
+     */
+    public GetApplicationDetailRequest() {
+    }
+
+    /**
+     * Constructor with application credentials entity ID.
+     * @param id Application credentials entity ID.
+     */
+    public GetApplicationDetailRequest(Long id) {
+        this.id = id;
+    }
+
+    /**
+     * Constructor with details.
+     * @param id Application credentials entity ID.
+     * @param includeIos Whether to include iOS details.
+     * @param includeAndroid Whether to include Android details.
+     */
+    public GetApplicationDetailRequest(Long id, boolean includeIos, boolean includeAndroid) {
+        this.id = id;
+        this.includeIos = includeIos;
+        this.includeAndroid = includeAndroid;
+    }
+
+    /**
+     * Get application credentials entity ID.
+     * @return Application credentials entity ID.
+     */
+    public Long getId() {
+        return id;
+    }
+
+    /**
+     * Set application credentials entity ID.
+     * @param id Application credentials entity ID.
+     */
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    /**
+     * Get whether to include iOS details.
+     * @return Whether to include iOS details.
+     */
+    public boolean includeIos() {
+        return includeIos;
+    }
+
+    /**
+     * Set whether to include iOS details.
+     * @param includeIos Whether to include iOS details.
+     */
+    public void setIncludeIos(boolean includeIos) {
+        this.includeIos = includeIos;
+    }
+
+    /**
+     * Get whether to include Android details.
+     * @return Whether to include Android details.
+     */
+    public boolean includeAndroid() {
+        return includeAndroid;
+    }
+
+    /**
+     * Set whgether to include Android details.
+     * @param includeAndroid Whether to include Android details.
+     */
+    public void setIncludeAndroid(boolean includeAndroid) {
+        this.includeAndroid = includeAndroid;
+    }
+}

--- a/powerauth-push-model/src/main/java/io/getlime/push/model/request/RemoveAndroidRequest.java
+++ b/powerauth-push-model/src/main/java/io/getlime/push/model/request/RemoveAndroidRequest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018 Lime - HighTech Solutions s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getlime.push.model.request;
+
+/**
+ * Remove android configuration request.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class RemoveAndroidRequest {
+
+    private Long id;
+
+    /**
+     * Default constructor.
+     */
+    public RemoveAndroidRequest() {
+    }
+
+    /**
+     * Constructor with application credentials entity ID.
+     * @param id Application credentials entity ID.
+     */
+    public RemoveAndroidRequest(Long id) {
+        this.id = id;
+    }
+
+    /**
+     * Get application credentials entity ID.
+     * @return Application credentials entity ID.
+     */
+    public Long getId() {
+        return id;
+    }
+
+    /**
+     * Set application credentials entity ID.
+     * @param id Application credentials entity ID.
+     */
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+}

--- a/powerauth-push-model/src/main/java/io/getlime/push/model/request/RemoveIosRequest.java
+++ b/powerauth-push-model/src/main/java/io/getlime/push/model/request/RemoveIosRequest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018 Lime - HighTech Solutions s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getlime.push.model.request;
+
+/**
+ * Remove iOS configuration request.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class RemoveIosRequest {
+
+    private Long id;
+
+    /**
+     * Default constructor.
+     */
+    public RemoveIosRequest() {
+    }
+
+    /**
+     * Constructor with application credentials entity ID.
+     * @param id Application credentials entity ID.
+     */
+    public RemoveIosRequest(Long id) {
+        this.id = id;
+    }
+
+    /**
+     * Get application credentials entity ID.
+     * @return Application credentials entity ID.
+     */
+    public Long getId() {
+        return id;
+    }
+
+    /**
+     * Set application credentials entity ID.
+     * @param id Application credentials entity ID.
+     */
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+}

--- a/powerauth-push-model/src/main/java/io/getlime/push/model/request/UpdateAndroidRequest.java
+++ b/powerauth-push-model/src/main/java/io/getlime/push/model/request/UpdateAndroidRequest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2018 Lime - HighTech Solutions s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getlime.push.model.request;
+
+/**
+ * Update Android configuration request.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class UpdateAndroidRequest {
+
+    private Long id;
+    private String bundle;
+    private String token;
+
+    /**
+     * Default constructor.
+     */
+    public UpdateAndroidRequest() {
+    }
+
+    /**
+     * Constructor with details.
+     * @param id Application credentials entity ID.
+     * @param bundle Android bundle record.
+     * @param token Android token record (server key).
+     */
+    public UpdateAndroidRequest(Long id, String bundle, String token) {
+        this.id = id;
+        this.bundle = bundle;
+        this.token = token;
+    }
+
+    /**
+     * Get application credentials entity ID.
+     * @return Application credentials entity ID.
+     */
+    public Long getId() {
+        return id;
+    }
+
+    /**
+     * Set application credentials entity ID.
+     * @param id Application credentials entity ID.
+     */
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    /**
+     * Get the Android bundle record.
+     * @return The Android bundle record.
+     */
+    public String getBundle() {
+        return bundle;
+    }
+
+    /**
+     * Set the Android bundle record.
+     * @param bundle The Android bundle record.
+     */
+    public void setBundle(String bundle) {
+        this.bundle = bundle;
+    }
+
+    /**
+     * Get the Android token record.
+     * @return The Android token record.
+     */
+    public String getToken() {
+        return token;
+    }
+
+    /**
+     * Set the Android token record.
+     * @param token The Android token record.
+     */
+    public void setToken(String token) {
+        this.token = token;
+    }
+}

--- a/powerauth-push-model/src/main/java/io/getlime/push/model/request/UpdateIosRequest.java
+++ b/powerauth-push-model/src/main/java/io/getlime/push/model/request/UpdateIosRequest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2018 Lime - HighTech Solutions s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getlime.push.model.request;
+
+/**
+ * Update iOS configuration request.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class UpdateIosRequest {
+
+    private Long id;
+    private String bundle;
+    private String keyId;
+    private String teamId;
+    private String privateKeyBytesBase64;
+
+    /**
+     * Default constructor.
+     */
+    public UpdateIosRequest() {
+    }
+
+    /**
+     * Constructor with details.
+     * @param id Application credentials entity ID.
+     * @param bundle The iOS bundle record.
+     * @param keyId The iOS key ID record.
+     * @param teamId The iOS team ID record.
+     * @param privateKeyBytesBase64 Base64 encoded private key.
+     */
+    public UpdateIosRequest(Long id, String bundle, String keyId, String teamId, String privateKeyBytesBase64) {
+        this.id = id;
+        this.bundle = bundle;
+        this.keyId = keyId;
+        this.teamId = teamId;
+        this.privateKeyBytesBase64 = privateKeyBytesBase64;
+    }
+
+    /**
+     * Get application credentials entity ID.
+     * @return Application credentials entity ID.
+     */
+    public Long getId() {
+        return id;
+    }
+
+    /**
+     * Set application credentials entity ID.
+     * @param id Application credentials entity ID.
+     */
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    /**
+     * Get the iOS bundle record.
+     * @return The iOS bundle record.
+     */
+    public String getBundle() {
+        return bundle;
+    }
+
+    /**
+     * Set the iOS bundle record.
+     * @param bundle The iOS bundle record.
+     */
+    public void setBundle(String bundle) {
+        this.bundle = bundle;
+    }
+
+    /**
+     * Get the iOS key ID record.
+     * @return The iOS key ID record.
+     */
+    public String getKeyId() {
+        return keyId;
+    }
+
+    /**
+     * Set the iOS key ID record.
+     * @param keyId The iOS key ID record.
+     */
+    public void setKeyId(String keyId) {
+        this.keyId = keyId;
+    }
+
+    /**
+     * Get the iOS team ID record.
+     * @return The iOS team ID record.
+     */
+    public String getTeamId() {
+        return teamId;
+    }
+
+    /**
+     * Set the iOS team ID record.
+     * @param teamId The iOS team ID record.
+     */
+    public void setTeamId(String teamId) {
+        this.teamId = teamId;
+    }
+
+    /**
+     * Get base64 encoded private key.
+     * @return Base 64 encoded private key.
+     */
+    public String getPrivateKeyBytesBase64() {
+        return privateKeyBytesBase64;
+    }
+
+    /**
+     * Set base64 encoded private key.
+     * @param privateKeyBytesBase64 Base 64 encoded private key.
+     */
+    public void setPrivateKeyBytesBase64(String privateKeyBytesBase64) {
+        this.privateKeyBytesBase64 = privateKeyBytesBase64;
+    }
+}

--- a/powerauth-push-model/src/main/java/io/getlime/push/model/response/CreateApplicationResponse.java
+++ b/powerauth-push-model/src/main/java/io/getlime/push/model/response/CreateApplicationResponse.java
@@ -16,7 +16,7 @@
 package io.getlime.push.model.response;
 
 /**
- * Create application response.
+ * Response after creating Push Server application credentials entity based on existing PowerAuth server application.
  *
  * @author Roman Strobl, roman.strobl@wultra.com
  */

--- a/powerauth-push-model/src/main/java/io/getlime/push/model/response/CreateApplicationResponse.java
+++ b/powerauth-push-model/src/main/java/io/getlime/push/model/response/CreateApplicationResponse.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018 Lime - HighTech Solutions s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getlime.push.model.response;
+
+/**
+ * Create application response.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class CreateApplicationResponse {
+
+    private Long id;
+
+    /**
+     * Default constructor.
+     */
+    public CreateApplicationResponse() {
+    }
+
+    /**
+     * Constructor with application credentials entity ID.
+     * @param id Application credentials entity ID.
+     */
+    public CreateApplicationResponse(Long id) {
+        this.id = id;
+    }
+
+    /**
+     * Get application credentials entity ID.
+     * @return Application credentials entity ID.
+     */
+    public Long getId() {
+        return id;
+    }
+
+    /**
+     * Set application credentials entity ID.
+     * @param id Application credentials entity ID.
+     */
+    public void setId(Long id) {
+        this.id = id;
+    }
+}

--- a/powerauth-push-model/src/main/java/io/getlime/push/model/response/GetApplicationDetailResponse.java
+++ b/powerauth-push-model/src/main/java/io/getlime/push/model/response/GetApplicationDetailResponse.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2018 Lime - HighTech Solutions s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getlime.push.model.response;
+
+import io.getlime.push.model.entity.PushServerApplication;
+
+/**
+ * Get application credentials entity detail response.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class GetApplicationDetailResponse {
+
+    private PushServerApplication application;
+    private String iosBundle;
+    private String iosKeyId;
+    private String iosTeamId;
+    private String androidBundle;
+    private String androidToken;
+
+    /**
+     * Default constructor.
+     */
+    public GetApplicationDetailResponse() {
+    }
+
+    /**
+     * Get push server application.
+     * @return Push server application.
+     */
+    public PushServerApplication getApplication() {
+        return application;
+    }
+
+    /**
+     * Set push server application.
+     * @param application Push server application.
+     */
+    public void setApplication(PushServerApplication application) {
+        this.application = application;
+    }
+
+    /**
+     * Get the iOS bundle record.
+     * @return The iOS bundle record.
+     */
+    public String getIosBundle() {
+        return iosBundle;
+    }
+
+    /**
+     * Set the iOS bundle record.
+     * @param iosBundle The iOS bundle record.
+     */
+    public void setIosBundle(String iosBundle) {
+        this.iosBundle = iosBundle;
+    }
+
+    /**
+     * Get the iOS key record.
+     * @return The iOS key record.
+     */
+    public String getIosKeyId() {
+        return iosKeyId;
+    }
+
+    /**
+     * Set the iOS key record.
+     * @param iosKeyId The iOS key record.
+     */
+    public void setIosKeyId(String iosKeyId) {
+        this.iosKeyId = iosKeyId;
+    }
+
+    /**
+     * Get the iOS team ID record.
+     * @return The iOS team ID record.
+     */
+    public String getIosTeamId() {
+        return iosTeamId;
+    }
+
+    /**
+     * Set the iOS team ID record.
+     * @param iosTeamId The iOS team ID record.
+     */
+    public void setIosTeamId(String iosTeamId) {
+        this.iosTeamId = iosTeamId;
+    }
+
+    /**
+     * Get the Android bundle record.
+     * @return The Android bundle record.
+     */
+    public String getAndroidBundle() {
+        return androidBundle;
+    }
+
+    /**
+     * Set the Android bundle record.
+     * @param androidBundle The Android bundle record.
+     */
+    public void setAndroidBundle(String androidBundle) {
+        this.androidBundle = androidBundle;
+    }
+
+    /**
+     * Get the Android token (server key) record.
+     * @return The Android token (server key) record.
+     */
+    public String getAndroidToken() {
+        return androidToken;
+    }
+
+    /**
+     * Set the Android token (server key) record.
+     * @param androidToken The Android token (server key) record.
+     */
+    public void setAndroidToken(String androidToken) {
+        this.androidToken = androidToken;
+    }
+}

--- a/powerauth-push-model/src/main/java/io/getlime/push/model/response/GetApplicationListResponse.java
+++ b/powerauth-push-model/src/main/java/io/getlime/push/model/response/GetApplicationListResponse.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 Lime - HighTech Solutions s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getlime.push.model.response;
+
+import io.getlime.push.model.entity.PushServerApplication;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Get application list response.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class GetApplicationListResponse {
+
+    private List<PushServerApplication> applicationList = new ArrayList<>();
+
+    /**
+     * Default constructor.
+     */
+    public GetApplicationListResponse() {
+    }
+
+    /**
+     * Constructor with application list.
+     * @param applicationList Application list.
+     */
+    public GetApplicationListResponse(List<PushServerApplication> applicationList) {
+        this.applicationList = applicationList;
+    }
+
+    /**
+     * Get application list.
+     * @return Application list.
+     */
+    public List<PushServerApplication> getApplicationList() {
+        return applicationList;
+    }
+
+    /**
+     * Set application list.
+     * @param applicationList Application list.
+     */
+    public void setApplicationList(List<PushServerApplication> applicationList) {
+        this.applicationList = applicationList;
+    }
+}

--- a/powerauth-push-server/pom.xml
+++ b/powerauth-push-server/pom.xml
@@ -96,7 +96,12 @@
         <dependency>
             <groupId>io.getlime.security</groupId>
             <artifactId>powerauth-push-model</artifactId>
-            <version>0.21.0</version>
+            <version>${powerauth.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.getlime.security</groupId>
+            <artifactId>powerauth-push-client</artifactId>
+            <version>${powerauth.version}</version>
         </dependency>
         <dependency>
             <groupId>io.getlime.security</groupId>
@@ -127,12 +132,6 @@
                     <artifactId>android-json</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>io.getlime.security</groupId>
-            <artifactId>powerauth-push-client</artifactId>
-            <version>${powerauth.version}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.h2database</groupId>

--- a/powerauth-push-server/src/main/java/io/getlime/push/configuration/PowerAuthWebServiceConfiguration.java
+++ b/powerauth-push-server/src/main/java/io/getlime/push/configuration/PowerAuthWebServiceConfiguration.java
@@ -151,18 +151,22 @@ public class PowerAuthWebServiceConfiguration {
     public PushServerClient pushServerClient() {
         // TODO - this code will be obsoleted by universal PA admin in release 2018.12, the resolution of service URI is only temporary
         String host;
-        String port;
+        Integer port;
+        String scheme;
         try {
             MBeanServer beanServer = ManagementFactory.getPlatformMBeanServer();
             Set<ObjectName> objectNames = beanServer.queryNames(new ObjectName("*:type=Connector,*"),
                     Query.match(Query.attr("protocol"), Query.value("HTTP/1.1")));
             host = InetAddress.getLocalHost().getHostAddress();
-            port = objectNames.iterator().next().getKeyProperty("port");
+            ObjectName objectName = objectNames.iterator().next();
+            port = (Integer) beanServer.getAttribute(objectName, "localPort");
+            scheme = (String) beanServer.getAttribute(objectName, "scheme");
         } catch (Exception e) {
             host = "127.0.0.1";
-            port = "8080";
+            port = 8080;
+            scheme = "http";
         }
-        return new PushServerClient("http://"+host+":"+port+"/powerauth-push-server");
+        return new PushServerClient(scheme + "://" + host + ":" + port + "/powerauth-push-server");
     }
 
 }

--- a/powerauth-push-server/src/main/java/io/getlime/push/configuration/PowerAuthWebServiceConfiguration.java
+++ b/powerauth-push-server/src/main/java/io/getlime/push/configuration/PowerAuthWebServiceConfiguration.java
@@ -15,6 +15,7 @@
  */
 package io.getlime.push.configuration;
 
+import io.getlime.push.client.PushServerClient;
 import io.getlime.security.powerauth.soap.spring.client.PowerAuthServiceClient;
 import org.apache.ws.security.WSConstants;
 import org.springframework.beans.factory.annotation.Value;
@@ -25,7 +26,13 @@ import org.springframework.oxm.jaxb.Jaxb2Marshaller;
 import org.springframework.ws.client.support.interceptor.ClientInterceptor;
 import org.springframework.ws.soap.security.wss4j.Wss4jSecurityInterceptor;
 
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import javax.management.Query;
 import javax.net.ssl.*;
+import java.lang.management.ManagementFactory;
+import java.net.InetAddress;
+import java.util.Set;
 
 /**
  * Default PowerAuth Service configuration.
@@ -133,6 +140,29 @@ public class PowerAuthWebServiceConfiguration {
             client.setInterceptors(interceptors);
         }
         return client;
+    }
+
+
+    /**
+     * Initialize PowerAuth 2.0 Push server client.
+     * @return Push server client.
+     */
+    @Bean
+    public PushServerClient pushServerClient() {
+        // TODO - this code will be obsoleted by universal PA admin in release 2018.12, the resolution of service URI is only temporary
+        String host;
+        String port;
+        try {
+            MBeanServer beanServer = ManagementFactory.getPlatformMBeanServer();
+            Set<ObjectName> objectNames = beanServer.queryNames(new ObjectName("*:type=Connector,*"),
+                    Query.match(Query.attr("protocol"), Query.value("HTTP/1.1")));
+            host = InetAddress.getLocalHost().getHostAddress();
+            port = objectNames.iterator().next().getKeyProperty("port");
+        } catch (Exception e) {
+            host = "127.0.0.1";
+            port = "8080";
+        }
+        return new PushServerClient("http://"+host+":"+port+"/powerauth-push-server");
     }
 
 }

--- a/powerauth-push-server/src/main/java/io/getlime/push/controller/rest/AdministrationController.java
+++ b/powerauth-push-server/src/main/java/io/getlime/push/controller/rest/AdministrationController.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2018 Lime - HighTech Solutions s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getlime.push.controller.rest;
+
+import com.google.common.io.BaseEncoding;
+import io.getlime.core.rest.model.base.request.ObjectRequest;
+import io.getlime.core.rest.model.base.response.ObjectResponse;
+import io.getlime.core.rest.model.base.response.Response;
+import io.getlime.push.errorhandling.exceptions.PushServerException;
+import io.getlime.push.model.entity.PushServerApplication;
+import io.getlime.push.model.request.*;
+import io.getlime.push.model.response.CreateApplicationResponse;
+import io.getlime.push.model.response.GetApplicationDetailResponse;
+import io.getlime.push.model.response.GetApplicationListResponse;
+import io.getlime.push.repository.AppCredentialsRepository;
+import io.getlime.push.repository.model.AppCredentialsEntity;
+import io.getlime.push.service.batch.storage.AppCredentialStorageMap;
+import io.getlime.security.powerauth.soap.spring.client.PowerAuthServiceClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import java.util.*;
+
+/**
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+@Controller
+@RequestMapping(value = "admin/app")
+public class AdministrationController {
+
+    private final PowerAuthServiceClient powerAuthClient;
+    private final AppCredentialsRepository appCredentialsRepository;
+    private final AppCredentialStorageMap appCredentialStorageMap;
+
+    /**
+     * Constructor with injected fields.
+     * @param powerAuthClient PowerAuth service client.
+     * @param appCredentialsRepository Application credentials repository.
+     * @param appCredentialStorageMap Application credentials storage map.
+     */
+    @Autowired
+    public AdministrationController(PowerAuthServiceClient powerAuthClient, AppCredentialsRepository appCredentialsRepository, AppCredentialStorageMap appCredentialStorageMap) {
+        this.powerAuthClient = powerAuthClient;
+        this.appCredentialsRepository = appCredentialsRepository;
+        this.appCredentialStorageMap = appCredentialStorageMap;
+    }
+
+    /**
+     * List applications configured in Push Server.
+     * @return Application list response.
+     */
+    @RequestMapping(value = "list", method = RequestMethod.POST)
+    public @ResponseBody ObjectResponse<GetApplicationListResponse> listApplications() {
+        final GetApplicationListResponse response = new GetApplicationListResponse();
+        final Iterable<AppCredentialsEntity> appCredentials = appCredentialsRepository.findAll();
+        final List<PushServerApplication> appList = new ArrayList<>();
+        for (AppCredentialsEntity appCredentialsEntity : appCredentials) {
+            PushServerApplication app = new PushServerApplication();
+            app.setId(appCredentialsEntity.getId());
+            app.setAppId(appCredentialsEntity.getAppId());
+            app.setAppName(powerAuthClient.getApplicationDetail(appCredentialsEntity.getAppId()).getApplicationName());
+            app.setIos(appCredentialsEntity.getIosPrivateKey() != null);
+            app.setAndroid(appCredentialsEntity.getAndroidServerKey() != null);
+            appList.add(app);
+        }
+        response.setApplicationList(appList);
+        return new ObjectResponse<>(response);
+    }
+
+    /**
+     * List applications which are not yet configured in Push Server.
+     * @return Application list response.
+     */
+    @RequestMapping(value = "unconfigured/list", method = RequestMethod.POST)
+    public @ResponseBody ObjectResponse<GetApplicationListResponse> createApplication() {
+        GetApplicationListResponse response = new GetApplicationListResponse();
+        // Get all applications in PA Server
+        final List<io.getlime.powerauth.soap.GetApplicationListResponse.Applications> applicationList = powerAuthClient.getApplicationList();
+
+        // Get all applications that are already set up
+        final Iterable<AppCredentialsEntity> appCredentials = appCredentialsRepository.findAll();
+
+        // Compute intersection by app ID
+        Set<Long> identifiers = new HashSet<>();
+        for (AppCredentialsEntity appCred: appCredentials) {
+            identifiers.add(appCred.getAppId());
+        }
+        for (io.getlime.powerauth.soap.GetApplicationListResponse.Applications app : applicationList) {
+            if (!identifiers.contains(app.getId())) {
+                PushServerApplication applicationToAdd = new PushServerApplication();
+                applicationToAdd.setId(app.getId());
+                applicationToAdd.setAppName(app.getApplicationName());
+                // add apps in intersection
+                response.getApplicationList().add(applicationToAdd);
+            }
+        }
+        return new ObjectResponse<>(response);
+    }
+
+    /**
+     * Get application credentials entity details.
+     * @param request Application detail request.
+     * @return Application detail response.
+     * @throws PushServerException Thrown when application credentials entity could not be found.
+     */
+    @RequestMapping(value = "detail", method = RequestMethod.POST)
+    public @ResponseBody ObjectResponse<GetApplicationDetailResponse> getApplicationDetail(@RequestBody ObjectRequest<GetApplicationDetailRequest> request) throws PushServerException {
+        final GetApplicationDetailResponse response = new GetApplicationDetailResponse();
+        final AppCredentialsEntity appCredentialsEntity = findAppCredentialsEntityById(request.getRequestObject().getId());
+        final PushServerApplication app = new PushServerApplication();
+        app.setId(appCredentialsEntity.getId());
+        app.setAppId(appCredentialsEntity.getAppId());
+        app.setIos(appCredentialsEntity.getIosPrivateKey() != null);
+        app.setAndroid(appCredentialsEntity.getAndroidServerKey() != null);
+        app.setAppName(powerAuthClient.getApplicationDetail(appCredentialsEntity.getAppId()).getApplicationName());
+        response.setApplication(app);
+        if (request.getRequestObject().includeIos()) {
+            response.setIosBundle(appCredentialsEntity.getIosBundle());
+            response.setIosKeyId(appCredentialsEntity.getIosKeyId());
+            response.setIosTeamId(appCredentialsEntity.getIosTeamId());
+        }
+        if (request.getRequestObject().includeAndroid()) {
+            response.setAndroidBundle(appCredentialsEntity.getAndroidBundle());
+            response.setAndroidToken(appCredentialsEntity.getAndroidServerKey());
+        }
+        return new ObjectResponse<>(response);
+    }
+
+    /**
+     * Create application.
+     * @param request Create application request.
+     * @return Create application response.
+     */
+    @RequestMapping(value = "create", method = RequestMethod.POST)
+    public @ResponseBody ObjectResponse<CreateApplicationResponse> createApplication(@RequestBody ObjectRequest<CreateApplicationRequest> request) {
+        final AppCredentialsEntity appCredentialsEntity = new AppCredentialsEntity();
+        appCredentialsEntity.setAppId(request.getRequestObject().getAppId());
+        AppCredentialsEntity newAppCredentialsEntity = appCredentialsRepository.save(appCredentialsEntity);
+        final CreateApplicationResponse response = new CreateApplicationResponse(newAppCredentialsEntity.getId());
+        return new ObjectResponse<>(response);
+    }
+
+    /**
+     * Update iOS configuration.
+     * @param request Update iOS configuration request.
+     * @return Response.
+     * @throws PushServerException Thrown when application credentials entity could not be found.
+     */
+    @RequestMapping(value = "ios/update", method = RequestMethod.POST)
+    public @ResponseBody Response updateIos(@RequestBody ObjectRequest<UpdateIosRequest> request) throws PushServerException {
+        final UpdateIosRequest requestObject = request.getRequestObject();
+        final AppCredentialsEntity appCredentialsEntity = findAppCredentialsEntityById(requestObject.getId());
+        byte[] privateKeyBytes = BaseEncoding.base64().decode(requestObject.getPrivateKeyBytesBase64());
+        appCredentialsEntity.setIosPrivateKey(privateKeyBytes);
+        appCredentialsEntity.setIosTeamId(requestObject.getTeamId());
+        appCredentialsEntity.setIosKeyId(requestObject.getKeyId());
+        appCredentialsEntity.setIosBundle(requestObject.getBundle());
+        appCredentialsRepository.save(appCredentialsEntity);
+        appCredentialStorageMap.cleanByKey(appCredentialsEntity.getAppId());
+        return new Response();
+    }
+
+    /**
+     * Remove iOS configuration.
+     * @param request Remove iOS configuration request.
+     * @return Response.
+     * @throws PushServerException Thrown when application credentials entity could not be found.
+     */
+    @RequestMapping(value = "ios/remove", method = RequestMethod.POST)
+    public @ResponseBody Response removeIos(@RequestBody ObjectRequest<UpdateIosRequest> request) throws PushServerException {
+        final UpdateIosRequest requestObject = request.getRequestObject();
+        final AppCredentialsEntity appCredentialsEntity = findAppCredentialsEntityById(requestObject.getId());
+        appCredentialsEntity.setIosPrivateKey(null);
+        appCredentialsEntity.setIosTeamId(null);
+        appCredentialsEntity.setIosKeyId(null);
+        appCredentialsEntity.setIosBundle(null);
+        appCredentialsRepository.save(appCredentialsEntity);
+        appCredentialStorageMap.cleanByKey(requestObject.getId());
+        return new Response();
+    }
+
+    /**
+     * Update Android configuration.
+     * @param request Update Android configuration request.
+     * @return Response.
+     * @throws PushServerException Thrown when application credentials entity could not be found.
+     */
+    @RequestMapping(value = "android/update", method = RequestMethod.POST)
+    public @ResponseBody Response updateAndroid(@RequestBody ObjectRequest<UpdateAndroidRequest> request) throws PushServerException {
+        final UpdateAndroidRequest requestObject = request.getRequestObject();
+        final AppCredentialsEntity appCredentialsEntity = findAppCredentialsEntityById(requestObject.getId());
+        appCredentialsEntity.setAndroidBundle(requestObject.getBundle());
+        appCredentialsEntity.setAndroidServerKey(requestObject.getToken());
+        appCredentialsRepository.save(appCredentialsEntity);
+        appCredentialStorageMap.cleanByKey(appCredentialsEntity.getAppId());
+        return new Response();
+    }
+
+    /**
+     * Remove Android configuration.
+     * @param request Remove Android configuration request.
+     * @return Response.
+     * @throws PushServerException Thrown when application credentials entity could not be found.
+     */
+    @RequestMapping(value = "android/remove", method = RequestMethod.POST)
+    public @ResponseBody Response removeAndroid(@RequestBody ObjectRequest<RemoveAndroidRequest> request) throws PushServerException {
+        final RemoveAndroidRequest requestObject = request.getRequestObject();
+        final AppCredentialsEntity appCredentialsEntity = findAppCredentialsEntityById(requestObject.getId());
+        appCredentialsEntity.setAndroidBundle(null);
+        appCredentialsEntity.setAndroidServerKey(null);
+        appCredentialsRepository.save(appCredentialsEntity);
+        appCredentialStorageMap.cleanByKey(requestObject.getId());
+        return new Response();
+    }
+
+    /**
+     * Find app credentials entity by ID.
+     * @param id App credentials ID.
+     * @return App credentials entity.
+     * @throws PushServerException Thrown when application credentials entity does not exists.
+     */
+    private AppCredentialsEntity findAppCredentialsEntityById(Long id) throws PushServerException {
+        final Optional<AppCredentialsEntity> appCredentialsEntityOptional = appCredentialsRepository.findById(id);
+        if (!appCredentialsEntityOptional.isPresent()) {
+            throw new PushServerException("Application credentials with entered ID does not exist");
+        }
+        return appCredentialsEntityOptional.get();
+    }
+}

--- a/powerauth-push-server/src/main/resources/application.properties
+++ b/powerauth-push-server/src/main/resources/application.properties
@@ -45,7 +45,7 @@ powerauth.push.service.applicationEnvironment=
 powerauth.push.service.campaign.batchSize=100000
 
 # APNs Configuration
-powerauth.push.service.apns.useDevelopment=false
+powerauth.push.service.apns.useDevelopment=true
 powerauth.push.service.apns.proxy.enabled=false
 powerauth.push.service.apns.proxy.url=127.0.0.1
 powerauth.push.service.apns.proxy.port=8080

--- a/powerauth-push-server/src/main/resources/application.properties
+++ b/powerauth-push-server/src/main/resources/application.properties
@@ -45,7 +45,7 @@ powerauth.push.service.applicationEnvironment=
 powerauth.push.service.campaign.batchSize=100000
 
 # APNs Configuration
-powerauth.push.service.apns.useDevelopment=true
+powerauth.push.service.apns.useDevelopment=false
 powerauth.push.service.apns.proxy.enabled=false
 powerauth.push.service.apns.proxy.url=127.0.0.1
 powerauth.push.service.apns.proxy.port=8080

--- a/powerauth-push-server/src/main/webapp/WEB-INF/jsp/applicationCreate.jsp
+++ b/powerauth-push-server/src/main/webapp/WEB-INF/jsp/applicationCreate.jsp
@@ -42,7 +42,7 @@
                         <select name="appId" class="form-control" style="width: 200px;">
                             <c:forEach items="${applications}" var="item">
                                 <option value="<c:out value="${item.id}"/>">
-                                    <c:out value="${item.applicationName}"/>
+                                    <c:out value="${item.appName}"/>
                                 </option>
                             </c:forEach>
                         </select>

--- a/powerauth-push-server/src/main/webapp/WEB-INF/jsp/error.jsp
+++ b/powerauth-push-server/src/main/webapp/WEB-INF/jsp/error.jsp
@@ -5,7 +5,7 @@
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
 
 <jsp:include page="header.jsp">
-    <jsp:param name="pageTitle" value="PowerAuth 2.0 Push Server - Error"/>
+    <jsp:param name="pageTitle" value="PowerAuth Push Server - Error"/>
 </jsp:include>
 
 <div class="panel panel-danger">
@@ -15,10 +15,17 @@
     </div>
 
     <div class="panel-body">
-        <p>An unknown error occurred.</p>
-        <div class="code">
-            ${stacktrace}
-        </div>
+        <p>
+            <c:choose>
+                <c:when test="${not empty message}">${message}</c:when>
+                <c:otherwise>An unknown error occurred.</c:otherwise>
+            </c:choose>
+        </p>
+        <c:if test="${not empty stacktrace}">
+            <div class="code">
+                ${stacktrace}
+            </div>
+        </c:if>
     </div>
 
 </div>


### PR DESCRIPTION
This PR adds REST API for administration in Push Server.

I haven't removed the web interface in Push Server yet, it was migrated to REST API instead. The web controller code will be reused in PA universal admin, so it should not be an worthless effort. We can remove the web interface completely once PA universal admin is available.

@hvge I am adding you as reviewer as agreed with @petrdvorak.