### PR TITLE
Fix #196: Migrate documentation from GitHub wiki to code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,10 @@
 # PowerAuth Push Server
 
-PowerAuth Push Server is an optional application that facilitates sending APNs / FCM messages alongside the [PowerAuth Server](https://github.com/lime-company/lime-security-powerauth) installation. It uses PowerAuth Server to obtain information about users, device activation state and to provide extra security features.
+PowerAuth Push Server is an optional application that facilitates sending APNs / FCM messages alongside the [PowerAuth Server](https://github.com/wultra/powerauth-server) installation. It uses PowerAuth Server to obtain information about users, device activation state and to provide extra security features.
 
-## Deployment tutorials
+## Documentation
 
-- [Deploy PowerAuth Push Server](https://github.com/lime-company/lime-security-powerauth-push/wiki/Deploying-Push-Server)
-
-## Integration tutorials
-
-- [Integrate Your Applications With PowerAuth Push Server](https://github.com/lime-company/lime-security-powerauth-push/wiki/Push-Server-Integration)
-
-## Reference manual
-
-- [PowerAuth Push Server RESTful API](https://github.com/lime-company/lime-security-powerauth-push/wiki/Push-Server-API)
-- [PowerAuth Push Server Database Structure](https://github.com/lime-company/lime-security-powerauth-push/wiki/Push-Server-Database)
+- For the most recent documentation and tutorials, please visit [PowerAuth Push Server Documentation](./docs/Home.md)
 
 # License
 

--- a/docs/Deploying-Push-Server.md
+++ b/docs/Deploying-Push-Server.md
@@ -1,0 +1,151 @@
+---
+layout: page
+title: Deploying Push Server
+---
+
+Push Server is a Java EE application (packaged as an executable WAR file) that can be used to send push notifications to iOS or Android devices. This chapter explains what steps need to be taken in order to deploy PowerAuth Push Server.
+
+## Downloading Push Server
+
+You can download the latest `powerauth-push-server.war` at the releases page:
+
+- https://github.com/wultra/powerauth-push-server/releases
+
+## Database
+
+### Setting Up Database Tables
+
+The PowerAuth Push Server requires several new tables to be set up - refer to the separate documentation for the detailed description of these tables:
+
+- [PowerAuth Push Server Database Structure](./Push-Server-Database.md)
+
+The new tables may or may not reside in the same database that you use for your PowerAuth deployment.
+
+### Connecting Server to Database
+
+The default database connectivity parameters in `powerauth-push-server.war` are following (MySQL defaults):
+
+```sh
+spring.datasource.url=jdbc:mysql://localhost:3306/powerauth
+spring.datasource.username=powerauth
+spring.datasource.password=
+spring.datasource.driver-class-name=com.mysql.jdbc.Driver
+spring.jpa.hibernate.ddl-auto=none
+```
+
+These parameters are of course only for the testing purposes, they are not suitable for production environment. They should be overridden for your production environment using a standard [Spring database connectivity related properties](https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-sql.html#boot-features-connect-to-production-database).
+
+As you can see, these credentials are the same as for the PowerAuth Server. You may use the same database for both applications but it is not required - Push Server can have own database.
+
+## Configuration
+
+The default implementation of a PowerAuth Push Server has only one compulsory configuration parameter `powerauth.service.url` that configures the SOAP endpoint location of a PowerAuth Server. The default value for this property points to `localhost`:
+
+```bash
+powerauth.service.url=http://localhost:8080/powerauth-java-server/soap
+```
+
+There are several optional configuration options you may want to set up.
+
+### Configuration of Push service URL
+
+Push server contains REST API which needs to be configured in case Push Server runs on non-standard port, non-standard context path or uses HTTPS. You can configure the service URL using following property:
+
+```
+powerauth.push.service.url=http://localhost:8080/powerauth-push-server
+```
+
+### Enabling Storing of Sent Push Messages
+
+You can enable storing of sent messages in database using following property:
+
+```
+powerauth.push.service.message.storage.enabled=true
+```
+
+### APNS Environment Configuration
+
+In order to separate development and production environment on APNS, you may want to set following property:
+
+```
+powerauth.push.service.apns.useDevelopment=false
+```
+
+### Data-Only Notifications for FCM
+
+In case you prefer only data notifications for the FCM service, you may want to enable following flag:
+
+```sh
+powerauth.push.service.fcm.dataNotificationOnly=true
+```
+
+If this flag is set to `true`, push server will use a key in `data` payload for title and subtitle, instead of placing them in the `notification` payload, like so:
+
+```json
+{
+    "to": "asdfgh...fcm....token",
+    "data": {
+        "_notification": {
+            "title": "Hello world",
+            "subtitle": "Oh, my wife..."
+        }
+    }
+}
+```
+
+### Running Behind Proxy
+
+In order to run PowerAuth Push server behind the proxy, you simply need to configure additional properties. See [Running Behind Proxy](./Running-Behind-Proxy.md) chapter for details.
+
+### Disabling SSL Validation During Development
+
+_(optional)_ While this is **strongly discouraged in production environment** (we cannot emphasize this enough), some development environments may use self-signed certificate for HTTPS communication. In case PowerAuth SOAP service uses HTTPS with such certificate, and in case you are not able to correctly configure a custom keystore in your server container, you may disable SSL certificate validation by setting this property:
+
+```bash
+powerauth.service.ssl.acceptInvalidSslCertificate=true
+```
+
+### Setting Up Credentials
+
+_(optional)_ In case PowerAuth Server uses a [restricted access flag in the server configuration](https://github.com/wultra/powerauth-server/docs/Deploying-PowerAuth-Server.md#enabling-powerauth-server-security), you need to configure credentials for the PowerAuth Push Server so that it can connect to the SOAP service:
+
+```sh
+powerauth.service.security.clientToken=
+powerauth.service.security.clientSecret=
+```
+
+The credentials are stored in the `pa_integration` table.
+
+_Note: For SOAP interface, PowerAuth Server uses WS-Security, `UsernameToken` validation (plain text password). The RESTful interface is secured using Basic HTTP Authentication (pre-emptive)._
+
+## Using up ALPN
+
+PowerAuth Push Server uses [Pushy](https://github.com/relayrides/pushy) to send notifications. Since Pushy uses the new HTTP/2 interface for sending APNs messages, underlying server must support this protocol. As a result, Java runtime / application container must support HTTP/2 as well.
+
+### APNL and Tomcat 8.0
+
+Put `alpn-boot` library (available [here](https://mvnrepository.com/artifact/org.mortbay.jetty.alpn/alpn-boot)) in `${CATALINA_HOME}/lib` folder and make sure to start Tomcat with `-Xbootclasspath/p:${CATALINA_HOME}/lib/alpn-boot.jar` parameters, so that the library is on classpath.
+
+## Deploying Push Server
+
+### Inside the Container
+
+You can deploy PowerAuth Push Server into any Java EE container.
+
+The default configuration works best with Apache Tomcat server running on default port 8080. In this case, the deployed server is accessible on `http://localhost:8080/powerauth-push-server/`.
+
+To deploy PowerAuth Push Server to Apache Tomcat, simply copy the WAR file in your `webapps` folder or deploy it using the "Tomcat Web Application Manager" application (usually deployed on default Tomcat address `http://localhost:8080/manager`).
+
+*__Important note: Since PowerAuth Push Server is a very simple application with direct access to the PowerAuth Server SOAP services, it must not be under any circumstances published publicly and must be constrained to the in-house closed infrastructure. The only exception to this rule is the requirement to open up ports for the purpose of communication with APNs and FCM services - the push notifications apparently would not work without access to the primary push service providers.__*
+
+## Outside the Container
+
+You can also execute WAR file directly using the following command:
+
+```bash
+java -jar powerauth-push-server.war
+```
+
+_Note: You can overwrite the port using `-Dserver.port=8090` parameter to avoid port conflicts._
+
+*__Important note: Since PowerAuth Push Server is a very simple application with direct access to the PowerAuth Server SOAP services, it must not be under any circumstances published publicly and must be constrained to the in-house closed infrastructure. The only exception to this rule is the requirement to open up ports for the purpose of communication with APNs and FCM services - the push notifications apparently would not work without access to the primary push service providers.__*

--- a/docs/Deploying-Push-Server.md
+++ b/docs/Deploying-Push-Server.md
@@ -1,7 +1,4 @@
----
-layout: page
-title: Deploying Push Server
----
+# Deploying Push Server
 
 Push Server is a Java EE application (packaged as an executable WAR file) that can be used to send push notifications to iOS or Android devices. This chapter explains what steps need to be taken in order to deploy PowerAuth Push Server.
 

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -7,19 +7,19 @@ PowerAuth Push Server is an optional application that facilitates sending APNs /
 
 ## Deployment tutorials
 
-- [Deploy PowerAuth Push Server](Deploying-Push-Server.md)
+- [Deploy PowerAuth Push Server](./Deploying-Push-Server.md)
 - [Migration Instructions](./Migration-Instructions.md)
 
 ## Integration tutorials
 
-- [Integrate Your Applications With PowerAuth Push Server](Push-Server-Integration.md)
+- [Integrate Your Applications With PowerAuth Push Server](./Push-Server-Integration.md)
 
 ## Reference manual
 
-- [PowerAuth Push Server RESTful API](Push-Server-API.md)
-- [PowerAuth Push Server Database Structure](Push-Server-Database.md)
+- [PowerAuth Push Server RESTful API](./Push-Server-API.md)
+- [PowerAuth Push Server Database Structure](./Push-Server-Database.md)
 
-**Technical Topics**
+##Technical Topics
 
 - [Mapping Abstract Payload to APNS/FCM](./Push-Message-Payload-Mapping.md)
 - [Running Behind Proxy](./Running-Behind-Proxy.md)

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -1,0 +1,29 @@
+---
+layout: page
+title: PowerAuth Push Server
+---
+
+PowerAuth Push Server is an optional application that facilitates sending APNs / FCM messages alongside the [PowerAuth Server](https://github.com/wultra/powerauth-server) installation. It uses PowerAuth Server to obtain information about users, device activation state and to provide extra security features.
+
+## Deployment tutorials
+
+- [Deploy PowerAuth Push Server](Deploying-Push-Server.md)
+- [Migration Instructions](./Migration-Instructions.md)
+
+## Integration tutorials
+
+- [Integrate Your Applications With PowerAuth Push Server](Push-Server-Integration.md)
+
+## Reference manual
+
+- [PowerAuth Push Server RESTful API](Push-Server-API.md)
+- [PowerAuth Push Server Database Structure](Push-Server-Database.md)
+
+**Technical Topics**
+
+- [Mapping Abstract Payload to APNS/FCM](./Push-Message-Payload-Mapping.md)
+- [Running Behind Proxy](./Running-Behind-Proxy.md)
+
+# License
+
+All sources are licensed using Apache 2.0 license, you can use them with no restriction. If you are using PowerAuth, please let us know. We will be happy to share and promote your project.

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -1,25 +1,22 @@
----
-layout: page
-title: PowerAuth Push Server
----
+# PowerAuth Push Server Documentation
 
 PowerAuth Push Server is an optional application that facilitates sending APNs / FCM messages alongside the [PowerAuth Server](https://github.com/wultra/powerauth-server) installation. It uses PowerAuth Server to obtain information about users, device activation state and to provide extra security features.
 
-## Deployment tutorials
+## Deployment Tutorials
 
 - [Deploy PowerAuth Push Server](./Deploying-Push-Server.md)
 - [Migration Instructions](./Migration-Instructions.md)
 
-## Integration tutorials
+## Integration Tutorials
 
 - [Integrate Your Applications With PowerAuth Push Server](./Push-Server-Integration.md)
 
-## Reference manual
+## Reference Manual
 
 - [PowerAuth Push Server RESTful API](./Push-Server-API.md)
 - [PowerAuth Push Server Database Structure](./Push-Server-Database.md)
 
-##Technical Topics
+## Technical Topics
 
 - [Mapping Abstract Payload to APNS/FCM](./Push-Message-Payload-Mapping.md)
 - [Running Behind Proxy](./Running-Behind-Proxy.md)

--- a/docs/Migration-Instructions.md
+++ b/docs/Migration-Instructions.md
@@ -1,0 +1,8 @@
+---
+layout: page
+title: Migration Instructions
+---
+
+This page contains PowerAuth Push Server migration instructions.
+
+- [PowerAuth Push Server 0.21.0](./PowerAuth-Push-Server-0.21.0.md)

--- a/docs/Migration-Instructions.md
+++ b/docs/Migration-Instructions.md
@@ -1,7 +1,4 @@
----
-layout: page
-title: Migration Instructions
----
+# Migration Instructions
 
 This page contains PowerAuth Push Server migration instructions.
 

--- a/docs/PowerAuth-Push-Server-0.21.0.md
+++ b/docs/PowerAuth-Push-Server-0.21.0.md
@@ -1,7 +1,4 @@
----
-layout: page
-title: Migration from 0.19.0 to 0.21.0
----
+# Migration from 0.19.0 to 0.21.0
 
 This guide contains instructions for migration from PowerAuth Push Server version 0.19.0 to version 0.21.0.
 

--- a/docs/PowerAuth-Push-Server-0.21.0.md
+++ b/docs/PowerAuth-Push-Server-0.21.0.md
@@ -1,0 +1,104 @@
+---
+layout: page
+title: Migration from 0.19.0 to 0.21.0
+---
+
+This guide contains instructions for migration from PowerAuth Push Server version 0.19.0 to version 0.21.0.
+
+## Database changes
+
+Following DB changes occurred between version 0.19.0 and 0.21.0:
+
+## Updated database columns for FCM
+
+* Table `push_app_credentials` - added column `android_private_key` which contains the Firebase service account private key used when obtaining access tokens for FCM HTTP v1 API.
+* Table `push_app_credentials` - added column `android_project_id` which contains the Firebase project ID.
+* Table `push_app_credentials` - dropped column `android_server_key` which was used by legacy FCM HTTP API.
+* Table `push_app_credentials` - dropped column `android_bundle` which was replaced by `android_project_id`.
+
+Migration scripts are available for Oracle and MySQL.
+
+DB migration script for Oracle:
+```sql
+--
+--  Updated columns for FCM
+--
+
+ALTER TABLE PUSH_APP_CREDENTIALS ADD ANDROID_PRIVATE_KEY BLOB DEFAULT NULL;
+ALTER TABLE PUSH_APP_CREDENTIALS ADD ANDROID_PROJECT_ID VARCHAR2(255) DEFAULT NULL;
+ALTER TABLE PUSH_APP_CREDENTIALS DROP COLUMN ANDROID_SERVER_KEY;
+ALTER TABLE PUSH_APP_CREDENTIALS DROP COLUMN ANDROID_BUNDLE;
+```
+
+DB migration script for MySQL:
+```sql
+--
+--   Updated columns for FCM
+--
+
+alter table push_app_credentials add `android_private_key` blob DEFAULT NULL;
+alter table push_app_credentials add `android_project_id` varchar(255) DEFAULT NULL;
+alter table push_app_credentials drop column `android_server_key`;
+alter table push_app_credentials drop column `android_bundle`;
+```
+
+## Dropped database columns for legacy old end-to-end encryption support
+DB migration script for Oracle and MySQL:
+```sql
+--
+--   Dropped columns for legacy end-to-end encryption
+--
+
+ALTER TABLE PUSH_DEVICE_REGISTRATION DROP COLUMN ENCRYPTION_KEY;
+ALTER TABLE PUSH_DEVICE_REGISTRATION DROP COLUMN ENCRYPTION_KEY_INDEX;
+
+ALTER TABLE PUSH_MESSAGE DROP COLUMN IS_ENCRYPTED;
+```
+
+## Database indexes
+
+You can apply following database indexes to improve database performance of Push Server.
+
+The DDL script is identical for all supported databases:
+
+```sql
+CREATE UNIQUE INDEX PUSH_APP_CRED_APP ON PUSH_APP_CREDENTIALS(APP_ID);
+
+CREATE INDEX PUSH_DEVICE_APP_TOKEN ON PUSH_DEVICE_REGISTRATION(APP_ID, PUSH_TOKEN);
+CREATE INDEX PUSH_DEVICE_USER_APP ON PUSH_DEVICE_REGISTRATION(USER_ID, APP_ID);
+CREATE INDEX PUSH_DEVICE_ACTIVATION ON PUSH_DEVICE_REGISTRATION(ACTIVATION_ID);
+
+CREATE INDEX PUSH_MESSAGE_STATUS ON PUSH_MESSAGE(STATUS);
+
+CREATE INDEX PUSH_CAMPAIGN_SENT ON PUSH_CAMPAIGN(IS_SENT);
+
+CREATE INDEX PUSH_CAMPAIGN_USER_CAMPAIGN ON PUSH_CAMPAIGN_USER(CAMPAIGN_ID, USER_ID);
+CREATE INDEX PUSH_CAMPAIGN_USER_DETAIL ON PUSH_CAMPAIGN_USER(USER_ID);
+```
+
+## Storing of sent push messages disabled by default
+
+Push server no longer stores sent push messages. You can enable storing of sent messages in database using following property:
+
+```
+powerauth.push.service.message.storage.enabled=true
+```
+
+## Configuration of Push service URL
+
+Push server contains a new REST API which needs to be configured in case Push Server runs on non-standard port, non-standard context path or uses HTTPS. You can configure the service URL using following property:
+
+```
+powerauth.push.service.url=http://localhost:8080/powerauth-push-server
+```
+
+## Migration to FCM HTTP API v1
+
+Push server started to use [FCM HTTP API v1](https://firebase.google.com/docs/cloud-messaging/migrate-v1) in version 0.21.0.
+
+The configuration parameters have changed for FCM HTTP API v1:
+- `Private key` needs to be configured instead of server key (which was removed from configuration).
+- `Project ID` needs to be configured.
+
+You can obtain both parameters from [Firebase Console](https://console.firebase.google.com). The project ID is visible in *Project Settings* | *General*. The private key can be generated using *Project Settings* | *Service Accounts* | *Firebase Admin SDK*, as described in [FCM documentation](https://firebase.google.com/docs/cloud-messaging/auth-server). Use the whole generated JSON file when configuring private key in Push server.
+

--- a/docs/Push-Message-Payload-Mapping.md
+++ b/docs/Push-Message-Payload-Mapping.md
@@ -1,7 +1,4 @@
----
-layout: page
-title: Push Message Payload Mapping
----
+# Push Message Payload Mapping
 
 The push server provides a convenient wrapper on top of the push messages sent to various platforms (APNS, FCM). This chapter describes what fields of the abstract push message are mapped to particular fields of APNS or FCM payload.
 

--- a/docs/Push-Message-Payload-Mapping.md
+++ b/docs/Push-Message-Payload-Mapping.md
@@ -1,0 +1,75 @@
+---
+layout: page
+title: Push Message Payload Mapping
+---
+
+The push server provides a convenient wrapper on top of the push messages sent to various platforms (APNS, FCM). This chapter describes what fields of the abstract push message are mapped to particular fields of APNS or FCM payload.
+
+## Abstract Push Message Object
+
+Abstract push message payload is represented using this object:
+
+```java
+public class PushMessageBody {
+
+    private String title;
+    private String body;
+    private Integer badge;
+    private String sound;
+    private String icon;
+    private String category;
+    private String collapseKey;
+    private Date validUntil;
+    private Map<String, Object> extras;
+
+}
+```
+
+## APNS Mapping
+
+Attributes of the abstract push message object are mapped to APNS payload in following way:
+
+
+| Abstract Message Attributes | APNS Mapped Attributes  |
+|-----------------------------|-------------------------|
+| `title`                     | `aps.alert.title`       |
+| `body`                      | `aps.alert.body`        |
+| `badge`                     | `aps.badge`             |
+| `category`                  | `aps.category`          |
+| `sound`                     | `aps.sound`             |
+| `icon`                      | _ignored_               |
+| `extras`                    | `[key:value]` custom data|
+| `collapseKey`               | `aps.thread-id`         |
+| `validUntil`                | Message expiration time on APNS servers (technical attribute), mapped to apns-expiration HTTP header.|
+
+For the documentation of the APNS payload reference, please read the official Apple documentation:
+
+- [Local and Remote Notification Programming Guide](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/APNSOverview.html#//apple_ref/doc/uid/TP40008194-CH8-SW1)
+
+### Silent Messages
+
+In case a push message is marked with the `silent` flag, we add `content-available = 1` key to the `aps` payload.
+
+## FCM Mapping
+
+Attributes of the abstract push message object are mapped to FCM payload in following way:
+
+| Abstract Message Attribute      | FCM Mapped Attributes |
+|---------------------------------|------------------------|
+| `title`                         | `notification.title`   |
+| `body`                          | `notification.body`    |
+| `badge`                         | _ignored_              |
+| `category`                      | `notification.tag`     |
+| `sound`                         | `notification.sound`   |
+| `icon`                          | `notification.icon`
+| `collapseKey`                   | `collapse_key`         |
+| `validUntil`                    | _ignored_              |
+| `extras`                        | `data`                 |
+
+For the documentation of the FCM payload reference, please read the official Google documentation:
+
+- [Cloud Messaging - About FCM Messages](https://firebase.google.com/docs/cloud-messaging/concept-options)
+
+### Silent Messages
+
+In case a push message is marked with the `silent` flag, we do not add attributes that trigger visible push notifications (attributes with `notification.*` path), even if they are present in the abstract push message object.

--- a/docs/Push-Server-API.md
+++ b/docs/Push-Server-API.md
@@ -1,0 +1,843 @@
+---
+layout: page
+title: Push Server API
+---
+
+Push Server provides a simple to use RESTful API for the 3rd party integration purposes. The API contains methods related with:
+
+- [Service](#service)
+- [Device](#device)
+- [Message](#message)
+- [Campaign](#campaign)
+
+Following endpoints are published in PowerAuth 2.0 Push Server RESTful API:
+
+## Methods
+
+##### **Request**
+- Headers:
+    - `Content-Type: application/json`
+- required extensive details stored in `requestObject`
+
+#### **Response**
+- Status Code: `200`
+- Headers:
+    - `Content-Type: application/json`
+- extensive details stored in `responsetObject`
+
+#### Device Management
+
+- `POST` [/push/device/create](#create-device) - Create new device registration
+- `POST` [/push/device/delete](#delete-device) - Remove registered device
+- `POST` [/push/device/status/update](#update-device-status) - Update the status of the activation so that when activation associated with given device is not active, no notifications are sent to the device.
+
+#### Sending Push Messages
+
+- `POST` [/push/message/send](#send-message) - Send single message to provided device
+- `POST` [/push/message/batch/send](#send-message-batch) - Send message batch to multiple devices
+
+#### Sending Campaign Notifications
+
+- `POST` [/push/campaign/send/live/${id}](#send-campaign) - Send notifications to users from campaign
+- `POST` [/push/campaign/send/test/${id}](#send-test-campaign) - Send notification to test users
+
+#### Campaign Management
+
+- `POST` [/push/campaign/create](#create-campaign) - Create new campaign
+- `POST` [/push/campaign/${ID}/delete](#delete-campaign) - Delete specific campaign
+- `POST` [/push/campaign/${ID}/user/delete](#delete-users-from-campaign) - Delete users from specific campaign
+- `PUT` [/push/campaign/${ID}/user/add](#add-users-to-campaign) - Add users to specific campaign
+- `GET` [/push/campaign/${ID}/detail](#get-campaign) - Return specific campaign
+- `GET` [/push/campaign/list/?all={true|false}](#get-list-of-campaigns) - Return actual list of campaigns
+- `GET` [/push/campaign/${ID}/user/list?page=${PAGE}&size=${SIZE}](#get-users-from-campaign) - Return paged list of users from specific campaign
+
+#### Service Status
+
+- `GET` [/push/service/status](#service) - Return status of service
+
+### Error Handling
+
+PowerAuth 2.0 Push Server uses following format for error response body, accompanied with an appropriate HTTP status code. Besides the HTTP error codes that application server may return regardless of server application (such as 404 when resource is not found or 503 when server is down), following status codes may be returned:
+
+|`status`|`HTTP code`       |Description|
+|---     |---          |---|
+|OK      |200          |No issue|
+|ERROR   |400          |Issue with a request format, or issue of the business logic|
+|ERROR   |401          | Unauthorized, invalid security token configuration|
+
+All error responses that are produced by the PowerAuth 2.0 Push Server have following body:
+
+```json
+
+{
+    "status": "ERROR",
+    "responseObject": {
+        "code": "ERROR_GENERIC",
+        "message": "Campaign with entered ID does not exist"
+    }
+}
+```
+
+- `status` - _OK_ | _ERROR_
+- `code` - _ERROR_GENERIC_ | _ERROR_DATABASE_
+- `message` - Message that describes certain error.
+
+## Service
+
+Describes basic information of application.
+
+### Service Status
+
+
+Send a system status response, with basic information about the running application.
+
+<table>
+<tr>
+<td>Method</td>
+<td><code>GET</code></td>
+</tr>
+<tr>
+<td>Resource URI</td>
+<td>/push/service/status</td>
+</tr>
+</table>
+
+#### **Response**
+
+```json
+{
+    "status": "OK",
+    "responseObject": {
+        "applicationName": "powerauth-push",
+        "applicationDisplayName": "PowerAuth 2.0 Push Server",
+        "applicationEnvironment": "",
+        "version": "0.21.0",
+        "buildTime": "2019-01-22T14:59:14.954+0000",
+        "timestamp": "2019-01-22T15:00:28.399+0000"
+    }
+}
+```
+
+- `applicationName` - Application name.
+- `applicationDisplayName` - Application display name.
+- `applicationEnvironment` - Application environment.
+- `version` - Version of Push server.
+- `buildTime` - Timestamp when the powerauth-push-server.war file was built.
+- `timestamp` - Current time on application.
+
+## Device
+
+Represents mobile device with iOS or Android that is capable to receive a push notification. Device has to first register with APNS or FCM to obtain push token.
+Then it has to forward the push token to the push server end-point. After that push server is able to send push notification to the device.
+
+### Create Device
+
+Create a new device push token (platform specific). Optionally, the call may include also `activationId`, so that the token is associated with given user in the PowerAuth 2.0 Server.
+
+_Note: Since this endpoint is usually called by the back-end service, it is not secured in any way. It's the service that calls this endpoint responsibility to assure that the device is somehow authenticated before the push token is assigned with given activationId value, so that there are no incorrect bindings._
+
+<table>
+<tr>
+<td>Method</td>
+<td><code>POST</code></td>
+</tr>
+<tr>
+<td>Resource URI</td>
+<td>/push/device/create</td>
+</tr>
+</table>
+
+#### **Request**
+
+```json
+{
+    "requestObject": {
+        "appId": 2,
+        "token": "1234567890987654321234567890",
+        "platform": "ios",
+        "activationId": "49414e31-f3df-4cea-87e6-f214ca3b8412"
+    }
+}
+```
+
+- `appId` - Application that device is using.
+- `token` - Identifier for device.
+- `platform` - "_ios_ | _android_"
+- `activationId` - Activation identifier
+
+_Note: Activation ID is optional._
+
+#### **Response**
+
+```json
+{
+    "status": "OK"
+}
+```
+
+### Delete Device
+
+Removes registered device based on the push token value.
+
+<table>
+<tr>
+<td>Method</td>
+<td><code>POST</code></td>
+</tr>
+<tr>
+<td>Resource URI</td>
+<td>/push/device/remove</td>
+</tr>
+</table>
+
+#### **Request**
+
+```json
+{
+    "requestObject": {
+        "appId": 2,
+        "token": "12456789098321234567890"
+    }
+}
+```
+
+- `appId` - Application that device is using.
+- `token` - Identifier for device.
+
+#### **Response**
+
+```json
+{
+    "status": "OK"
+}
+```
+
+### Update Device Status
+
+Update the status of given device registration based on the associated activation ID. This can help assure that registration is in non-active state and cannot receive personal messages.
+
+<table>
+<tr>
+<td>Method</td>
+<td><code>POST</code></td>
+</tr>
+<tr>
+<td>Resource URI</td>
+<td>/push/device/status/update</td>
+</tr>
+</table>
+
+#### **Request**
+
+```json
+{
+    "activationId": "49414e31-f3df-4cea-87e6-f214ca3b8412"
+}
+```
+
+- `activationId` - Identifier of activation.
+
+#### **Response**
+
+```json
+{
+    "status": "OK"
+}
+```
+
+## Message
+
+Represents a single notification sent to the device. It provides an abstraction of APNS or FCM message payload.
+
+### Send Message
+
+Send a single push message to given user via provided application, optionally to the specific device represented by given `activationId`.
+
+<table>
+<tr>
+<td>Method</td>
+<td><code>POST</code></td>
+</tr>
+<tr>
+<td>Resource URI</td>
+<td>/push/message/send</td>
+</tr>
+</table>
+
+#### **Request**
+
+```json
+{
+    "requestObject": {
+        "appId": 2,
+        "message": {
+            "activationId": "49414e31-f3df-4cea-87e6-f214ca3b8412",
+            "userId": "123",
+            "attributes": {
+                "personal": true,
+                "silent": true
+            },
+            "body": {
+                "title": "Balance update",
+                "body": "Your balance is now $745.00",
+                "badge": 3,
+                "sound": "default",
+                "icon": "custom-icon",
+                "category": "balance-update",
+                "collapseKey": "balance-update",
+                "validUntil": "2017-12-11T21:22:29.923Z",
+                "extras": {
+                    "_comment": "Any custom data."
+                }
+            }
+        }
+    }
+}
+
+```
+
+- `appId` - Application that user/s is/are using.
+- `message` - Body for notification creating.
+    - `userId` - Identifier of user.
+    - `activationId` - Identifier of specific activation, that usually corresponds to the device.
+    - `attributes` - Set of boolean variables
+        - `silent` - Sent silent push notification (If _true_, no system UI is displayed).
+        - `personal` - If _true_ and activation is not in `ACTIVE` state the message is not sent.
+    - `body` - Body object is described in [here](./Push-Message-Payload-Mapping.md)
+        - See [Push Message Payload Mapping](./Push-Message-Payload-Mapping.md) for details.
+
+#### **Response**
+
+```json
+{
+    "status": "OK"
+}
+```
+
+### Send Message Batch
+
+Sends a message message batch - each item in the batch represents a message to given user. The message is sent via provided application (optionally to the specific device represented by given `activationId`).
+
+<table>
+<tr>
+<td>Method</td>
+<td><code>POST</code></td>
+</tr>
+<tr>
+<td>Resource URI</td>
+<td>/push/message/batch/send</td>
+</tr>
+</table>
+
+#### **Request**
+
+```json
+{
+    "requestObject": {
+        "appId": 2,
+        "batch": [
+            {
+                "activationId": "49414e31-f3df-4cea-87e6-f214ca3b8412",
+                "userId": "123",
+                "attributes": {
+                    "personal": true,
+                    "silent": true
+                },
+                "body": {
+                    "title": "Balance update",
+                    "body": "Your balance is now $745.00",
+                    "badge": 3,
+                    "sound": "default",
+                    "icon": "custom-icon",
+                    "category": "balance-update",
+                    "collapseKey": "balance-update",
+                    "validUntil": "2017-12-11T21:22:29.923Z",
+                    "extras": {
+                        "_comment": "Any custom data."
+                    }
+                }
+            },
+            {
+                "activationId": "49414e31-f3df-4cea-87e6-f214ca3b8412",
+                "userId": "1234",
+                "attributes": {
+                    "personal": true,
+                    "silent": true
+                },
+                "body": {
+                    "title": "Balance update",
+                    "body": "Your balance is now $745.00",
+                    "badge": 3,
+                    "sound": "default",
+                    "icon": "custom-icon",
+                    "category": "balance-update",
+                    "collapseKey": "balance-update",
+                    "validUntil": "2017-12-11T21:22:29.923Z",
+                    "extras": {
+                        "_comment": "Any custom data."
+                    }
+                }
+            }
+        ]
+    }
+}
+
+```
+
+- `appId` - Application that user/s is/are using.
+- `batch` - List of messages, see [documentation for sending a single message](#send-message) for details
+
+#### **Response**
+
+```json
+{
+    "status": "OK",
+    "responseObject": {
+        "result": {
+            "ios": {
+                "sent": 1,
+                "pending": 0,
+                "failed": 0,
+                "total": 1
+            },
+            "android": {
+                "sent": 1,
+                "pending": 0,
+                "failed": 0,
+                "total": 1
+            }
+        }
+    }
+}
+```
+
+- `result` - Information about sending notifications.
+- `sent` - Number of sent notifications.
+- `failed` - Number of failed notifications.
+- `total` - Number of total notifications.
+
+## Campaign
+
+Used for informing closed group of users about some certain announcement containing message object described [here](./Push-Message-Payload-Mapping.md).
+
+Further campaign comes with:
+
+- application that campaign is using
+- timestamp of
+- creation
+- sending
+- sent status - Whether is sent or not.
+- devices - To prevent getting multiple messages on device. If there would be more than one user registered.
+
+### Create Campaign
+
+Create a campaign with application that campaign is using and certain message that contains parameters of message object.
+
+#### **Request**
+<table>
+<tr>
+<td>Method</td>
+<td><code>POST</code></td>
+</tr>
+<tr>
+<td>Resource URI</td>
+<td>/push/campaign/create</td>
+</tr>
+</table>
+
+```json
+{
+    "requestObject": {
+        "appId": "2",
+        "message": {
+            "title": "Balance update",
+            "body": "Your balance is now $745.00",
+            "badge": 3,
+            "sound": "default",
+            "icon": "custom-icon",
+            "category": "balance-update",
+            "collapseKey": "balance-update",
+            "validUntil": "2016-10-12T11:20:04Z",
+            "extras": {
+                "_comment": "Any custom data."
+            }      
+        }
+    }
+}
+```
+
+- `appId` - Identifier of application that campaign is using.
+- `message` - parameters of message object are described [here](./Push-Message-Payload-Mapping.md).
+
+_note: identifier of campaign is generated automatically_
+
+#### **Response**
+
+```json
+{
+    "status": "OK",
+    "responseObject": {
+        "id": "123456789012345678901234567890"
+    }
+}
+```
+
+- `id` - Assigned ID to campaign.
+
+### Delete Campaign
+
+Delete a specific campaign. Also users associated with this campaign are going to be deleted. If deletion was applied then deleted status is true.
+
+#### **Request**
+<table>
+<tr>
+<td>Method</td>
+<td><code>POST</code></td>
+</tr>
+<tr>
+<td>Resource URI</td>
+<td>/push/campaign/${ID}/delete</td>
+</tr>
+<tr>
+<td>Var ${ID} </td>
+<td>Campaign identifier</td>
+</tr>
+</table>
+
+```json
+{
+
+}
+```
+
+- empty request body
+
+#### **Response**
+
+```json
+{
+    "status": "OK",
+    "responseObject" : {
+        "deleted" : true
+    }
+}
+```
+
+- `deleted` - Indicate if deletion was applied.
+
+### Get Campaign
+
+Return details of a specific campaign.
+
+#### **Request**
+<table>
+<tr>
+<td>Method</td>
+<td><code>GET</code></td>
+</tr>
+<tr>
+<td>Resource URI</td>
+<td>/push/campaign/${ID}/detail</td>
+</tr>
+<tr>
+<td>Var ${ID} </td>
+<td>Campaign identifier</td>
+</tr>
+</table>
+
+#### **Response**
+
+```json
+{
+    "status": "OK",
+    "responseObject": {
+        "id": "10",
+        "appId": 2,
+        "sent": "false",
+        "message": {
+            "title": "Balance update",
+            "body": "Your balance is now $745.00",
+            "badge": 3,
+            "sound": "default",
+            "icon": "custom-icon",
+            "category": "balance-update",
+            "collapseKey": "balance-update",
+            "validUntil": "2016-10-12T11:20:04Z",
+            "extras": {
+                "_comment": "Any custom data."
+            }
+        }
+    }
+}
+```
+
+- `id` - Identifier of campaign.
+- `appId` - Identifier of application that campaign is using.
+- `sent` - Indicator if campaign was sent.
+- `message` - parameters of message object are described [here](./Push-Message-Payload-Mapping.md).
+
+### Get List Of Campaigns
+
+Return list of actually registered campaigns, based on `all` parameter. This parameter decides if return campaigns that are 'only sent'(statement _false_) or return all registered campaigns (statement _true_).
+
+#### **Request**
+<table>
+<tr>
+<td>Method</td>
+<td><code>GET</code></td>
+</tr>
+<tr>
+<td>Resource URI</td>
+<td>/push/campaign/list/?all={true|false}</td>
+</tr>
+</table>
+
+#### **Response**
+
+``` json
+{
+    "status": "OK",
+    "responseObject": [
+        {
+            "id": "10",
+            "appId": 2,
+            "sent": "false",
+            "message": {
+                "title": "Balance update",
+                "body": "Your balance is now $745.00",
+                "badge": 3,
+                "sound": "default",
+                "icon": "custom-icon",
+                "category": "balance-update",
+                "collapseKey": "balance-update",
+                "validUntil": "2016-10-12T11:20:04Z",
+                "extras": {
+                    "_comment": "Any custom data."
+                }
+            }
+            }, {
+                "id": "11",
+                "appId": 3,
+                "sent": "true",
+                "message": {
+                    "title": "Balance update",
+                    "body": "Your balance is now $300.00",
+                    "badge": 3,
+                    "sound": "default",
+                    "icon": "custom-icon",
+                    "category": "balance-update",
+                    "collapseKey": "balance-update",
+                    "validUntil": "2017-10-12T11:20:04Z",
+                    "extras": {
+                        "_comment": "Any custom data."
+                    }
+                }
+            }
+        ]
+    }
+```
+- array of campaigns
+- `id` - Identifier of campaign.
+- `appId` - Identifier of application that campaign is using.
+- `sent` - Indicator if campaign was sent.
+- `message` - parameters of message object are described [here](./Push-Message-Payload-Mapping.md).
+
+### Add Users To Campaign
+
+Associate users to a specific campaign. Users are identified in request body as an array of strings.
+
+#### **Request**
+<table>
+<tr>
+<td>Method</td>
+<td><code>PUT</code></td>
+</tr>
+<tr>
+<td>Resource URI</td>
+<td>/push/campaign/${ID}/user/add</td>
+</tr>
+<tr>
+<td>Var ${ID} </td>
+<td>Campaign identifier</td>
+</tr>
+</table>
+
+```json
+{
+    "requestObject": [
+        "1234567890",
+        "1234567891",
+        "1234567893"
+    ]
+}
+```
+- list of users
+
+#### **Response**
+
+```json
+{
+    "status": "OK"
+}
+```
+
+### Get Users From Campaign
+
+Return list users from a specific campaign. Users are shown in paginated format based on parameters assigned in URI.
+
+#### **Request**
+<table>
+<tr>
+<td>Method</td>
+<td><code>GET</code></td>
+</tr>
+<tr>
+<td>Resource URI</td>
+<td>/push/campaign/${ID}/user/list?page=${PAGE}&size=${SIZE}</td>
+</tr>
+<tr>
+<td>Var ${ID} </td>
+<td>Campaign identifier</td>
+</tr>
+<tr>
+<td>Var ${PAGE} </td>
+<td>Nubmer of page to show</td>
+</tr>
+<tr>
+<td>Var ${SIZE}</td>
+<td>Number of elements per page</td>
+</tr>
+</table>
+
+#### **Response**
+
+```json
+{
+    "status": "OK",
+    "page": 0,
+    "size": 4,
+    "responseObject": {
+        "campaignId": "1234",
+        "users": [
+            "1234567890",
+            "1234567892",
+            "1234567893"
+        ]
+    }
+}
+```
+
+- `page` - Actual page listed
+- `size` - Chosen number of users per page
+- `campaignId` - ID of a chosen campaign
+- `users` - Array of users based on pagination parameters
+
+### Delete Users From Campaign
+
+Delete users associated with a specific campaign. Users are identified request body as an array of strings.
+
+#### **Request**
+<table>
+<tr>
+<td>Method</td>
+<td><code>POST</code></td>
+</tr>
+<tr>
+<td>Resource URI</td>
+<td>/push/campaign/${ID}/user/delete</td>
+</tr>
+<tr>
+<td>Var ${ID} </td>
+<td>Campaign identifier</td>
+</tr>
+</table>
+
+```json
+{
+    "requestObject": [
+        "1234567890",
+        "1234567891",
+        "1234567893"
+    ]
+}
+```
+
+- list of users
+
+#### **Response**
+
+```json
+{
+    "status": "OK"
+}
+```
+
+### Send Test Campaign
+
+Send message from a specific campaign on test user to check rightness of that campaign.
+
+#### **Request**
+<table>
+<tr>
+<td>Method</td>
+<td><code>POST</code></td>
+</tr>
+<tr>
+<td>Resource URI</td>
+<td>/push/campaign/send/test/${ID}</td>
+<tr>
+<td>Var ${ID} </td>
+<td>Campaign identifier</td>
+</tr>
+</tr>
+</table>
+
+```json
+{
+    "requestObject": {
+        "userId": "1234567890"
+    }
+}
+```
+
+- `userId` - ID of test user, usually "1234567890"
+
+#### **Response**
+
+```json
+{
+    "status": "OK"
+}
+```
+
+### Send Campaign
+
+Send message from a specific campaign to devices belonged to users associated with that campaign. Whereas each device gets a campaign only once.
+
+If sending was successful then `sent` parameter is set on _true_ and `timestampSent` is set on current time.
+
+#### **Request**
+<table>
+<tr>
+<td>Method</td>
+<td><code>POST</code></td>
+</tr>
+<tr>
+<td>Resource URI</td>
+<td>/push/campaign/send/live/${ID}</td>
+</tr>
+<tr>
+<td>Var ${ID} </td>
+<td>Campaign identifier</td>
+</tr>
+</table>
+
+- empty request body
+
+#### **Response**
+
+```json
+{
+    "status": "OK"
+}
+```

--- a/docs/Push-Server-API.md
+++ b/docs/Push-Server-API.md
@@ -1,7 +1,4 @@
----
-layout: page
-title: Push Server API
----
+# Push Server API
 
 Push Server provides a simple to use RESTful API for the 3rd party integration purposes. The API contains methods related with:
 

--- a/docs/Push-Server-Database.md
+++ b/docs/Push-Server-Database.md
@@ -1,7 +1,4 @@
----
-layout: page
-title: Push Server Database
----
+# Push Server Database
 
 PowerAuth Push Server requires several new database tables in order to work.
 

--- a/docs/Push-Server-Database.md
+++ b/docs/Push-Server-Database.md
@@ -1,0 +1,125 @@
+---
+layout: page
+title: Push Server Database
+---
+
+PowerAuth Push Server requires several new database tables in order to work.
+
+Here are the [bootstrap schemes for MySQL and Oracle](https://github.com/wultra/powerauth-push-server/blob/master/docs/sql).
+
+## Tables
+
+- [Push devices](#push-devices-table)
+- [Push service credentials](#push-service-credentials-table)
+- [Push messages](#push-messages-table)
+- [Push campaigns](#push-campaigns-table)
+- [Push campaign users](#push-campaign-users-table)
+- [Push campaign devices](#push-campaign-devices-table)
+
+### Push Devices Table
+
+
+**Table name**: `push_device`
+
+**Purpose**: Stores push tokens specific for a given device.
+
+**Columns**:
+
+| Name | Type | Info | Note |
+|---|---|---|---|
+| id | BIGINT(20) | primary key, index, autoincrement | Unique device registration ID. |
+| activation_id | VARCHAR(37) | index | Application name, for example "Mobile Banking". |
+| user_id | BIGINT(20) | index | Associated user ID |
+| app_id | BIGINT(20) | index | Associated application ID |
+| platform | VARCHAR(30) | - | Mobile OS Platform ("ios", "android") |
+| push_token | VARCHAR(255) | - | Push token associated with a given device. Type of the token is determined by the `platform` column. |
+| timestamp_created | TIMESTAMP | - | Timestamp of the last device registration. |
+| is_active | INT(11) | - | PowerAuth 2.0 activation status (boolean), used as an activation status cache so that communication with PowerAuth 2.0 Server can be minimal. |
+
+### Push Service Credentials Table
+
+**Table name**: `push_app_credentials`
+
+**Purpose**: Stores per-app credentials used for communication with APNs / FCM.
+
+**Columns**:
+
+| Name | Type | Info | Note |
+|---|---|---|---|
+| id | BIGINT(20) | primary key, index, autoincrement | Unique credential record ID. |
+| app_id | BIGINT(20) | index | Associated application ID |
+| ios_key_id | VARCHAR(255) | - | Key ID used for identifying a private key in APNs service. |
+| ios_private_key | BLOB | - | Binary representation of P8 file with private key used for Apple's APNs service. |
+| ios_team_id | VARCHAR(255) | - | Team ID used for sending push notifications. |
+| ios_bundle | VARCHAR(255) | - | Application bundle ID, used as a APNs "topic". |
+| android_private_key | BLOB | - | Firebase service account private key used when obtaining access tokens for FCM HTTP v1 API. |
+| android_project_id | VARCHAR(255) | - | Firebase project ID, used when sending push messages using FCM. |
+
+### Push Messages Table
+
+**Table name**: `push_message`
+
+**Purpose**: Stores individual messages that were sent by the push server and their sent status.
+
+**Columns**:
+
+| Name | Type | Info | Note |
+|---|---|---|---|
+| id | BIGINT(20) | primary key, index, autoincrement | Unique message record ID. |
+| device_registration_id | INT | index | Associated device registration (device that is used to receive the message), for the purpose of resend on fail operation. |
+| user_id | BIGINT(20) | index | Associated user ID. |
+| activation_id | VARCHAR(37) | index | PowerAuth 2.0 activation ID. |
+| silent | INT | - | Flag indicating if the message was "silent" (0 = NO, 1 = YES) |
+| personal | INT | - | Flag indicating if the message was "personal" - sent only on active devices (0 = NO, 1 = YES) |
+| message_body | TEXT | - | Payload of the message in a unified server format. This format is later translated in a platform specific payload. |
+| timestamp_created | TIMESTAMP | - | Date and time when the record was created. |
+| status | INT | - | Value indicating message send status. (-1 = FAILED, 0 = PENDING, 1 = SENT) |
+
+### Push Campaigns Table
+
+**Table name**: `push_campaign`
+
+**Purpose**: Stores particular campaigns together with notification messages
+
+**Columns**:
+
+| Name | Type | Info | Note |
+|---|---|---|---|
+| id | BIGINT(20) | primary key, index, autoincrement | Unique campaign record ID. |
+| appid | BIGINT(20) | index | Associated Application identifier |
+| message | TEXT | - | Certain notification that is written in unified format |
+| sent| INT(1) | - | Flag indicating if campaign was successfully sent |
+| timestamp_created | TIMESTAMP | - | Timestamp of campaign creation |
+| timestamp_sent | TIMESTAMP | - | Timestamp of campaign successful sending |
+
+### Push Campaign Users Table
+
+**Table name**: `push_campaign_user`
+
+**Purpose**: Stores users who are going to get notification from specific campaign
+
+**Columns**:
+
+| Name | Type | Info | Note |
+|---|---|---|---|
+| id | BIGINT(20) | primary key, index, autoincrement | Unique user ID |
+| campaign_id | BIGINT(20) | index | Identifier of campaign that is user related to |
+| user_id | BIGINT(20) | index | Identifier of user, can occur multiple times in different campaigns |
+| timestamp_created | TIMESTAMP | - | Timestamp of user creation |
+
+### Push Campaign Devices Table
+
+**Table name**: `push_campaign_device`
+
+**Purpose**: Stores devices related to certain campaign to ensure that each device will receive only one message
+
+**Columns**:
+
+| Name | Type | Info | Note |
+|---|---|---|---|
+| id | BIGINT(20) | primary key, index, autoincrement | Unique device ID |
+| campaign_id | BIGINT(20) | index | Identifier of campaign that is device related to |
+| platform | VARCHAR(20) | - | Platform that is device running on |
+| token | VARCHAR(255) | - | Push token associated with a given device |
+| status | INT(11) | - | Status used in concurrent sending. States: sent, sending, failed |
+| timestamp_created | TIMESTAMP | - | Timestamp of device creation |

--- a/docs/Push-Server-Integration.md
+++ b/docs/Push-Server-Integration.md
@@ -1,0 +1,152 @@
+---
+layout: page
+title: Integration with Push Server
+---
+
+In order to register devices and send push notifications, the Push Server needs to be integrated with server applications. The first application that must communicate with the Push Server is a mobile API application (the one that publishes service specific API for mobile application).
+
+## Prerequisites for the tutorial
+
+- Running PowerAuth Server with available SOAP interface.
+- Running PowerAuth Push Server with available RESTful interface.
+- Knowledge of applications based on Spring Framework.
+- Software: IDE - Spring Tool Suite, Java EE Application Server (Pivotal Server, Tomcat, ...)
+
+## Common integration steps
+
+### Adding Maven Dependency
+
+In order to be able to implement integration easily, add Push Server client Maven dependency to your `pom.xml` file:
+
+```xml
+<dependency>
+    <groupId>io.getlime.security</groupId>
+    <artifactId>powerauth-push-client</artifactId>
+    <version>${powerauth.push-server.version}</version>
+</dependency>
+```
+
+### Prepare a Service Client Configuration
+
+In order to connect to the PowerAuth Push Server, you need to add following configuration:
+
+```java
+@Configuration
+@ComponentScan(basePackages = {"io.getlime.push"})
+public class PowerAuthPushConfiguration {
+
+  @Bean
+  public PushServerClient pushServerClient() {
+    PushServerClient client = new PushServerClient();
+    client.setServiceBaseUrl("http://localhost:8080/powerauth-push-server");
+    return client;
+  }
+
+}
+```
+
+## Integration With Mobile API
+
+### Prepare the Device Registration Endpoint
+
+In order to implement generic device registration, implement a custom registration RESTful Endpoint that calls the Push Server under the hood, for example like so:
+
+```java
+@Controller
+@RequestMapping(value = "push")
+public class DeviceRegistrationController {
+
+    @Autowired
+    private PushServerClient pushServerClient;
+
+    private static final Long APP_ID = 1; // Replace by your app ID or use a configuration class
+
+    @RequestMapping(value="device/create", method = RequestMethod.POST)
+    public @ResponseBody String registerDevice(@RequestBody Map<String,String> request) {
+
+        // Get the values from the request
+        String platform = request.get("platform");
+        String token = request.get("push_token");
+
+        // Check if the context is authenticated - if it is, add activation ID.
+        // This assures that the activation is assigned with a correct device.
+        String activationId = null;
+        PowerAuthApiAuthentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null) {
+            activationId = authentication.getActivationId();
+        }
+
+        // Register the device and return response
+        boolean result = pushServerClient.registerDevice(APP_ID, token, MobilePlatform.valueOf(platform), activationId);
+        if (result) {
+            return "OK";
+        } else {
+            return "NOT_OK";
+        }
+    }
+}
+```
+
+The code checks for `PowerAuthApiAuthentication` instance in the security context and if it is present, it binds the activation ID with the push service token.
+
+**Note: We are using 'dummy' request (Map<String,String>) and response (String) objects. Replace them with your proprietary classes.**
+
+## Integrate with Push Producer Applications
+
+Push Producer Application is any application that sends push notification request. The purpose of the producer applications is to call service for push notification sending (single or batch):
+
+```java
+// Prepare push message object
+PushMessage push = new PushMessage();
+push.setUserId("123");
+
+// Set push message attributes
+push.getAttributes().setSilent(false);
+push.getAttributes().setPersonal(true);
+
+// Set push message body
+PushMessageBody body = new PushMessageBody();
+body.setTitle("Balance update");
+body.setBody("Your balance is now $745.00");
+body.setSound("default");
+body.setBadge(1);
+body.setCategory("balance");
+body.setCollapseKey("balance");
+body.setValidUntil(ISODate("2016-10-12T11:20:04Z").date());
+
+// Add custom message data attributes
+Map<String,Object> extras = new HashMap<>();
+extras.put("customKey", "customValue");
+extras.put("customDate", new Date());
+body.setExtras(extras);
+
+// Set the new push message body
+push.setBody(body);
+
+// Send single push message
+pushServerClient.sendNotification(APP_ID, push);
+
+// Send push message batch
+List<PushMessage> messageList = new ArrayList<>();
+messageList.add(push);
+pushServerClient.sendNotificationBatch(APP_ID, messageList);
+```
+
+## Other Tasks
+
+### Disabling SSL Certificate Validation
+
+In testing or development environments, you may disable SSL validation by setting an attribute when creating `PushServerClient` bean. Make sure that this setting is not used in production environment.
+
+```java
+@Bean
+public PushServerClient pushServerClient() {
+    PushServerClient client = new PushServerClient();
+    client.setServiceBaseUrl(powerAuthPushServiceUrl);
+    // whether invalid SSL certificates should be accepted
+    if (acceptInvalidSslCertificate) {
+        sslConfigurationService.trustAllCertificates();
+    }
+    return client;
+}
+```

--- a/docs/Push-Server-Integration.md
+++ b/docs/Push-Server-Integration.md
@@ -1,7 +1,4 @@
----
-layout: page
-title: Integration with Push Server
----
+# Integration with Push Server
 
 In order to register devices and send push notifications, the Push Server needs to be integrated with server applications. The first application that must communicate with the Push Server is a mobile API application (the one that publishes service specific API for mobile application).
 

--- a/docs/Running-Behind-Proxy.md
+++ b/docs/Running-Behind-Proxy.md
@@ -1,0 +1,45 @@
+---
+layout: page
+title: Running Behind Proxy
+---
+
+In case you would like to run push server behind a proxy, you need to configure following properties, otherwise service clients will not be able to resolve DNS records for APNS / FCM services:
+
+```bash
+# APNs Configuration
+powerauth.push.service.apns.proxy.enabled=false
+powerauth.push.service.apns.proxy.url=127.0.0.1
+powerauth.push.service.apns.proxy.port=8080
+powerauth.push.service.apns.proxy.username=
+powerauth.push.service.apns.proxy.password=
+
+# FCM Configuration
+powerauth.push.service.fcm.proxy.enabled=false
+powerauth.push.service.fcm.proxy.url=127.0.0.1
+powerauth.push.service.fcm.proxy.port=8080
+powerauth.push.service.fcm.proxy.username=
+powerauth.push.service.fcm.proxy.password=
+```
+
+In case the `*.username` value is empty, authentication is not used. Otherwise, username and password is used for the authentication with proxy.
+
+Of course, you need to set the properties according to your deployment model. For example, if you are running push server in Tomcat, add these properties in `powerauth-push-server.xml` context file placed in `${CATALINA_HOME}/conf/Catalina/localhost` folder, like so:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<Context>
+
+    <!-- ... other configurations ... -->
+
+    <!-- APNS -->
+    <Parameter name="powerauth.push.service.apns.proxy.enabled" value="true"/>
+    <Parameter name="powerauth.push.service.apns.proxy.url" value="10.64.0.99"/>
+    <Parameter name="powerauth.push.service.apns.proxy.port" value="8088"/>
+
+    <!-- FCM -->
+    <Parameter name="powerauth.push.service.fcm.proxy.enabled" value="true"/>
+    <Parameter name="powerauth.push.service.fcm.proxy.url" value="10.64.0.99"/>
+    <Parameter name="powerauth.push.service.fcm.proxy.port" value="8088"/>
+
+</Context>
+```

--- a/docs/Running-Behind-Proxy.md
+++ b/docs/Running-Behind-Proxy.md
@@ -1,7 +1,4 @@
----
-layout: page
-title: Running Behind Proxy
----
+# Running Behind Proxy
 
 In case you would like to run push server behind a proxy, you need to configure following properties, otherwise service clients will not be able to resolve DNS records for APNS / FCM services:
 

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -1,0 +1,19 @@
+**Deployment Tutorials**
+
+- [Home](./Home.md)
+- [Deploy Push Server](./Deploying-Push-Server.md)
+- [Migration Instructions](./Migration-Instructions.md)
+
+**Integration Tutorials**
+
+- [Integrate with Push Server](./Push-Server-Integration.md)
+
+**Reference Manual**
+
+- [Push Server RESTful API](./Push-Server-API.md)
+- [Push Server Database Structure](./Push-Server-Database.md)
+
+**Technical Topics**
+
+- [Mapping Abstract Payload to APNS/FCM](./Push-Message-Payload-Mapping.md)
+- [Running Behind Proxy](./Running-Behind-Proxy.md)


### PR DESCRIPTION
This pull request contains following changes:
- Fix #196: Migrate documentation from GitHub wiki to code
- Documentation updates for release 0.21.0
- Updated links due to migration from wiki to code
- Updated DDL and database structure
