### PR TITLE
Fix #133: Make FCM URL configurable

### DIFF
--- a/powerauth-push-server/src/main/java/io/getlime/push/configuration/PushServiceConfiguration.java
+++ b/powerauth-push-server/src/main/java/io/getlime/push/configuration/PushServiceConfiguration.java
@@ -74,6 +74,9 @@ public class PushServiceConfiguration {
     @Value("${powerauth.push.service.fcm.dataNotificationOnly}")
     private boolean fcmDataNotificationOnly;
 
+    @Value("${powerauth.push.service.fcm.sendMessageUrl}")
+    private String fcmSendMessageUrl;
+
     // Campaign Configuration
     @Value("${powerauth.push.service.campaign.batchSize}")
     private int campaignBatchSize;
@@ -332,6 +335,22 @@ public class PushServiceConfiguration {
      */
     public void setFcmDataNotificationOnly(boolean fcmDataNotificationOnly) {
         this.fcmDataNotificationOnly = fcmDataNotificationOnly;
+    }
+
+    /**
+     * Get FCM send message endpoint URL.
+     * @return FCM send message endpoint URL.
+     */
+    public String getFcmSendMessageUrl() {
+        return fcmSendMessageUrl;
+    }
+
+    /**
+     * Set FCM send message endpoint URL.
+     * @param fcmSendMessageUrl FCM send message endpoint URL.
+     */
+    public void setFcmSendMessageUrl(String fcmSendMessageUrl) {
+        this.fcmSendMessageUrl = fcmSendMessageUrl;
     }
 
     /**

--- a/powerauth-push-server/src/main/java/io/getlime/push/service/PushSendingWorker.java
+++ b/powerauth-push-server/src/main/java/io/getlime/push/service/PushSendingWorker.java
@@ -113,6 +113,14 @@ public class PushSendingWorker {
         }
         fcmClient.initializeWebClient();
         fcmClient.initializeGoogleCredential();
+        String fcmUrl = pushServiceConfiguration.getFcmSendMessageUrl();
+        if (fcmUrl.contains("projects/%s/")) {
+            // Configure project ID in FCM URL in case the project ID parameter is expected in configured URL
+            fcmClient.setFcmSendMessageUrl(String.format(fcmUrl, projectId));
+        } else {
+            // Set FCM url as is (e.g. for testing)
+            fcmClient.setFcmSendMessageUrl(fcmUrl);
+        }
         return fcmClient;
     }
 

--- a/powerauth-push-server/src/main/java/io/getlime/push/service/fcm/FcmClient.java
+++ b/powerauth-push-server/src/main/java/io/getlime/push/service/fcm/FcmClient.java
@@ -49,9 +49,6 @@ public class FcmClient {
 
     private static final Logger logger = LoggerFactory.getLogger(FcmClient.class);
 
-    // FCM URL for posting push messages
-    private static final String FCM_URL = "https://fcm.googleapis.com/v1/projects/%s/messages:send";
-
     // Time buffer for refresh access tokens
     private static final long REFRESH_TOKEN_TIME_BUFFER_SECONDS = 60L;
 
@@ -62,7 +59,7 @@ public class FcmClient {
     private final byte[] privateKey;
 
     // FCM send message URL
-    private final String fcmSendMessageUrl;
+    private String fcmSendMessageUrl;
 
     // Google Credential instance for obtaining access tokens
     private GoogleCredential googleCredential;
@@ -86,7 +83,6 @@ public class FcmClient {
         this.projectId = projectId;
         this.privateKey = privateKey;
         this.pushServiceConfiguration = pushServiceConfiguration;
-        this.fcmSendMessageUrl = String.format(FCM_URL, projectId);
         this.fcmConverter = fcmConverter;
     }
 
@@ -129,6 +125,14 @@ public class FcmClient {
                     return tcpClient;
                 });
         webClient = WebClient.builder().clientConnector(new ReactorClientHttpConnector(httpClient)).build();
+    }
+
+    /**
+     * Set the FCM send message endpoint URL.
+     * @param fcmSendMessageUrl FCM send message endpoint URL.
+     */
+    public void setFcmSendMessageUrl(String fcmSendMessageUrl) {
+        this.fcmSendMessageUrl = fcmSendMessageUrl;
     }
 
     /**
@@ -186,6 +190,10 @@ public class FcmClient {
         }
         if (projectId == null) {
             logger.error("Push message delivery failed because FCM project ID is not configured.");
+            return;
+        }
+        if (fcmSendMessageUrl == null) {
+            logger.error("Push message delivery failed because FCM send message URL is not configured.");
             return;
         }
 

--- a/powerauth-push-server/src/main/resources/application.properties
+++ b/powerauth-push-server/src/main/resources/application.properties
@@ -65,6 +65,7 @@ powerauth.push.service.fcm.proxy.port=8080
 powerauth.push.service.fcm.proxy.username=
 powerauth.push.service.fcm.proxy.password=
 powerauth.push.service.fcm.dataNotificationOnly=false
+powerauth.push.service.fcm.sendMessageUrl=https://fcm.googleapis.com/v1/projects/%s/messages:send
 
 # Disable JMX
 spring.jmx.enabled=false


### PR DESCRIPTION
I made the FCM URL configurable so that we can test Push Server performance with our own endpoint.