### PR TITLE
Fix #218: Use case sensitive index definition for MySQL

### DIFF
--- a/docs/PowerAuth-Push-Server-0.21.0.md
+++ b/docs/PowerAuth-Push-Server-0.21.0.md
@@ -56,8 +56,7 @@ ALTER TABLE PUSH_MESSAGE DROP COLUMN IS_ENCRYPTED;
 
 You can apply following database indexes to improve database performance of Push Server.
 
-The DDL script is identical for all supported databases:
-
+The DDL script for Oracle:
 ```sql
 CREATE UNIQUE INDEX PUSH_APP_CRED_APP ON PUSH_APP_CREDENTIALS(APP_ID);
 
@@ -71,6 +70,22 @@ CREATE INDEX PUSH_CAMPAIGN_SENT ON PUSH_CAMPAIGN(IS_SENT);
 
 CREATE INDEX PUSH_CAMPAIGN_USER_CAMPAIGN ON PUSH_CAMPAIGN_USER(CAMPAIGN_ID, USER_ID);
 CREATE INDEX PUSH_CAMPAIGN_USER_DETAIL ON PUSH_CAMPAIGN_USER(USER_ID);
+```
+
+The DDL script for MySQL:
+```sql
+CREATE UNIQUE INDEX `push_app_cred_app` ON `push_app_credentials`(`app_id`);
+
+CREATE INDEX `push_device_app_token` ON `push_device_registration`(`app_id`, `push_token`);
+CREATE INDEX `push_device_user_app` ON `push_device_registration`(`user_id`, `app_id`);
+CREATE INDEX `push_device_activation` ON `push_device_registration`(`activation_id`);
+
+CREATE INDEX `push_message_status` ON `push_message`(`status`);
+
+CREATE INDEX `push_campaign_sent` ON `push_campaign`(`is_sent`);
+
+CREATE INDEX `push_campaign_user_campaign` ON `push_campaign_user`(`campaign_id`, `user_id`);
+CREATE INDEX `push_campaign_user_detail` ON `push_campaign_user`(`user_id`);
 ```
 
 ## Storing of sent push messages disabled by default

--- a/docs/sql/mysql/create_push_server_schema.sql
+++ b/docs/sql/mysql/create_push_server_schema.sql
@@ -35,7 +35,7 @@ CREATE TABLE `push_message` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
-CREATE TABLE push_campaign (
+CREATE TABLE `push_campaign` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `app_id` bigint(20) NOT NULL,
   `message` text NOT NULL,
@@ -46,7 +46,7 @@ CREATE TABLE push_campaign (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
-CREATE TABLE push_campaign_user (
+CREATE TABLE `push_campaign_user` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `campaign_id` bigint(20) NOT NULL,
   `user_id` varchar(255) NOT NULL,
@@ -54,19 +54,19 @@ CREATE TABLE push_campaign_user (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
----
---- Indexes for better performance.
----
+--
+-- Indexes for better performance.
+--
 
-CREATE UNIQUE INDEX PUSH_APP_CRED_APP ON PUSH_APP_CREDENTIALS(APP_ID);
+CREATE UNIQUE INDEX `push_app_cred_app` ON `push_app_credentials`(`app_id`);
 
-CREATE INDEX PUSH_DEVICE_APP_TOKEN ON PUSH_DEVICE_REGISTRATION(APP_ID, PUSH_TOKEN);
-CREATE INDEX PUSH_DEVICE_USER_APP ON PUSH_DEVICE_REGISTRATION(USER_ID, APP_ID);
-CREATE INDEX PUSH_DEVICE_ACTIVATION ON PUSH_DEVICE_REGISTRATION(ACTIVATION_ID);
+CREATE INDEX `push_device_app_token` ON `push_device_registration`(`app_id`, `push_token`);
+CREATE INDEX `push_device_user_app` ON `push_device_registration`(`user_id`, `app_id`);
+CREATE INDEX `push_device_activation` ON `push_device_registration`(`activation_id`);
 
-CREATE INDEX PUSH_MESSAGE_STATUS ON PUSH_MESSAGE(STATUS);
+CREATE INDEX `push_message_status` ON `push_message`(`status`);
 
-CREATE INDEX PUSH_CAMPAIGN_SENT ON PUSH_CAMPAIGN(IS_SENT);
+CREATE INDEX `push_campaign_sent` ON `push_campaign`(`is_sent`);
 
-CREATE INDEX PUSH_CAMPAIGN_USER_CAMPAIGN ON PUSH_CAMPAIGN_USER(CAMPAIGN_ID, USER_ID);
-CREATE INDEX PUSH_CAMPAIGN_USER_DETAIL ON PUSH_CAMPAIGN_USER(USER_ID);
+CREATE INDEX `push_campaign_user_campaign` ON `push_campaign_user`(`campaign_id`, `user_id`);
+CREATE INDEX `push_campaign_user_detail` ON `push_campaign_user`(`user_id`);


### PR DESCRIPTION
The original index definition failed in Docker while it worked fine on my newer version of MySQL.