### PR TITLE
Fix #221: Add jboss-deployment-structure.xml file

### DIFF
--- a/docs/Deploying-Push-Server.md
+++ b/docs/Deploying-Push-Server.md
@@ -146,3 +146,7 @@ java -jar powerauth-push-server.war
 _Note: You can overwrite the port using `-Dserver.port=8090` parameter to avoid port conflicts._
 
 *__Important note: Since PowerAuth Push Server is a very simple application with direct access to the PowerAuth Server SOAP services, it must not be under any circumstances published publicly and must be constrained to the in-house closed infrastructure. The only exception to this rule is the requirement to open up ports for the purpose of communication with APNs and FCM services - the push notifications apparently would not work without access to the primary push service providers.__*
+
+## Deploying Push Server On JBoss / Wildfly
+
+Follow the extra instructions in chapter [Deploying Push Server on JBoss / Wildfly](./Deploying-Wildfly.md).

--- a/docs/Deploying-Wildfly.md
+++ b/docs/Deploying-Wildfly.md
@@ -1,0 +1,94 @@
+# Deploying Push Server on JBoss / Wildfly
+
+## JBoss Deployment Descriptor 
+
+Push Server contains the following configuration in `jboss-deployment-structure.xml` file for JBoss:
+
+```
+<?xml version="1.0"?>
+<jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.2">
+	<deployment>
+		<exclude-subsystems>
+			<!-- disable the logging subsystem because the application manages its own logging independently -->
+			<subsystem name="logging" />
+		</exclude-subsystems>
+
+		<dependencies>
+			<module name="com.wultra.powerauth.push-server.conf" />
+		</dependencies>
+		<local-last value="true" />
+	</deployment>
+</jboss-deployment-structure>
+```
+
+The deployment descriptor requires configuration of the `com.wultra.powerauth.push-server.conf` module.
+
+## JBoss Module for Push Server Configuration
+
+Create a new module in `PATH_TO_JBOSS/modules/system/layers/base/com/wultra/powerauth/push-server/conf/main`.
+
+The files described below should be added into this folder.
+
+### Main Module Configuration
+
+The `module.xml` configuration is used for module registration. It also adds resources from the module folder to classpath:
+```
+<?xml version="1.0" encoding="UTF-8"?>
+<module xmlns="urn:jboss:module:1.3" name="com.wultra.powerauth.push-server.conf">
+    <resources>
+        <resource-root path="." />
+    </resources>
+</module>
+```
+
+### Logging Configuration
+
+Use the `logback.xml` file to configure logging, for example:
+```
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration scan="true" scanPeriod="30 seconds">
+
+        <property name="LOG_FILE_DIR" value="/var/log/powerauth" />
+        <property name="LOG_FILE_NAME" value="push-server" />
+        <property name="INSTANCE_ID" value="${jboss.server.name}" />
+
+        <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+                <file>${LOG_FILE_DIR}/${LOG_FILE_NAME}-${INSTANCE_ID}.log</file>
+                <immediateFlush>true</immediateFlush>
+                <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+                        <fileNamePattern>${LOG_FILE_DIR}/${LOG_FILE_NAME}-${INSTANCE_ID}-%d{yyyy-MM-dd}-%i.log</fileNamePattern>
+                        <maxFileSize>10MB</maxFileSize>
+                        <maxHistory>5</maxHistory>
+                        <totalSizeCap>100MB</totalSizeCap>
+                </rollingPolicy>
+                <encoder>
+                        <charset>UTF-8</charset>
+                        <pattern>%d{ISO8601} [%thread] %-5level %logger{36} - %msg%n</pattern>
+                </encoder>
+        </appender>
+
+        <logger name="com.wultra" level="INFO" />
+        <logger name="io.getlime" level="INFO" />
+
+        <root level="INFO">
+                <appender-ref ref="FILE" />
+        </root>
+</configuration>
+```
+
+### Application Configuration
+
+The `application-ext.properties` file is used to override default configuration properties, for example:
+```
+# PowerAuth 2.0 Client configuration
+powerauth.service.url=http://[host]:[port]/powerauth-java-server/soap
+```
+
+Push Server Spring application uses the `ext` Spring profile which activates overriding of default properties by `application-ext.properties`.
+
+### Bouncy Castle Installation
+
+The Bouncy Castle module for JBoss / Wildfly needs to be enabled as a global module for Push Server.
+
+Follow the instructions in the [Installing Bouncy Castle](https://github.com/wultra/powerauth-server/blob/develop/docs/Installing-Bouncy-Castle.md) chapter of PowerAuth Server documentation. 
+Note that the instructions differ based on Java version and application server type.

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -2,6 +2,7 @@
 
 - [Home](./Readme.md)
 - [Deploy Push Server](./Deploying-Push-Server.md)
+- [Deploy Push Server on JBoss / Wildfly](./Deploying-Wildfly.md)
 - [Migration Instructions](./Migration-Instructions.md)
 
 **Integration Tutorials**

--- a/powerauth-push-server/src/main/java/io/getlime/push/configuration/PushServiceConfiguration.java
+++ b/powerauth-push-server/src/main/java/io/getlime/push/configuration/PushServiceConfiguration.java
@@ -17,12 +17,14 @@
 package io.getlime.push.configuration;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
 /**
  * @author Petr Dvorak, petr@wultra.com
  */
 @Configuration
+@ConfigurationProperties("ext")
 public class PushServiceConfiguration {
 
     @Value("${powerauth.push.service.applicationName}")

--- a/powerauth-push-server/src/main/resources/application.properties
+++ b/powerauth-push-server/src/main/resources/application.properties
@@ -1,3 +1,6 @@
+# Allow externalization of properties using application-ext.properties
+spring.profiles.active=ext
+
 # Spring MVC configuration
 spring.mvc.view.prefix=/WEB-INF/jsp/
 spring.mvc.view.suffix=.jsp

--- a/powerauth-push-server/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/powerauth-push-server/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.2">
+	<deployment>
+		<exclude-subsystems>
+			<!-- disable the logging subsystem because the application manages its own logging independently -->
+			<subsystem name="logging" />
+		</exclude-subsystems>
+
+		<dependencies>
+			<module name="com.wultra.powerauth.push-server.conf" />
+		</dependencies>
+		<local-last value="true" />
+	</deployment>
+</jboss-deployment-structure>


### PR DESCRIPTION
This pull request adds the deployment descriptor for JBoss / Wildfly and activates the `ext` profile to allow overriding of `application.properties`. It also includes documentation updates especially about deploying on JBoss / Wildfly.