### PR TITLE
Fix #229: Replace firebase-admin dependency

### DIFF
--- a/powerauth-push-server/pom.xml
+++ b/powerauth-push-server/pom.xml
@@ -106,6 +106,16 @@
             <groupId>com.google.firebase</groupId>
             <artifactId>firebase-admin</artifactId>
             <version>${firebase-admin.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>google-cloud-firestore</artifactId>
+                    <groupId>com.google.cloud</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>google-cloud-storage</artifactId>
+                    <groupId>com.google.cloud</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         
         <!-- Optional Native Cryptographic Provider -->


### PR DESCRIPTION
It is not easy to move the FCM model classes to our project because there are many other Google library dependencies in these classes. So at least I excluded the problematic depedencies reported by OWASP check.