### PR TITLE
Fix #233: Update Pushy dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,9 +80,10 @@
         <jackson.version>2.9.8</jackson.version>
         <javax.interceptor-api.version>1.2.2</javax.interceptor-api.version>
         <jsp-api.version>2.0</jsp-api.version>
+        <jstl.version>1.2.5</jstl.version>
         <lime.rest.version>1.1.0</lime.rest.version>
         <powerauth.version>0.22.0</powerauth.version>
-        <pushy.version>0.13.7</pushy.version>
+        <pushy.version>0.13.8</pushy.version>
         <tcnative.version>2.0.20.Final</tcnative.version>
         <swagger.version>2.9.2</swagger.version>
         <unirest.version>1.4.9</unirest.version>

--- a/powerauth-push-server/pom.xml
+++ b/powerauth-push-server/pom.xml
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>org.glassfish.web</groupId>
             <artifactId>javax.servlet.jsp.jstl</artifactId>
-            <version>1.2.5</version>
+            <version>${jstl.version}</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
@@ -153,11 +153,6 @@
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-joda</artifactId>
             <version>${jackson.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.projectreactor.ipc</groupId>
-            <artifactId>reactor-netty</artifactId>
-            <version>${reactor-netty.version}</version>
         </dependency>
 
         <!-- Dependencies for Java 11 -->


### PR DESCRIPTION
This pull request contains following dependency updates:
- Update of `pushy` dependency
- Parameterized `jstl` dependency version
- Removed `reactor-netty` dependency, it is no longer needed in Spring boot `2.1.5`