### PR TITLE
Update coverity scan settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ jdk:
 branches:
   only:
     - master
+    - coverity_scan
 env:
   global:
     - secure: "lN/1nBJvrLsBhDRJwoAKiu5Xv9dRyH7EJ4DC1AUgRfaz/2in8e9X8psluCxXiCkUqxJqjqIwp/IUWJyIgnUj1Tj8KT2dyR/wp68Q+tr3buRxGbZf9lAIirj44LB7ji5cxGKmuvJNY3M5hFaLoovquqacwB0FslnhssH/HpuSHMC2lyNXxnIduTLha/7AZAX7+xNTeRQ86cpVIh5/UJEhvqICdlywhsguAdeyyI/ZLRElLY07O3R9SJAaOgy95oDmSwq3IflIjBNhlxrWKYUUAkQFjM3HdwcmLbhP5aZAJWbrDRiAeXzJyqgvvo/oHS+AtSc8r68TvZ+O+H4d0XLbExrz4cFdXHKCJY/OuI6pwpXRWoXiPgEBpNodef5iGupU84ZxKiBGvSWEJNgGDSHLwUgVzEtOSPnvmeVGRHHi2hO9onOMKHPsJR8aHWg8VDcsf3kXIF7YVC2lvaO5Ubi9ESzjBoE3tQsQlcaHCOzYsXqI70DAH4lgZtabYRIWbFcbl+RSoNsrvh5HhMl17W0YM1a3+bXdF/Q926jFg506XDvYhyPy2DUoiwnSdtthxMJYYLTDSYjZDzykmCH0A2TM+iM2hJLP8LO/b7wLxj/lI2NhmRQzhI8pMhkBHa97kMH3eTX+QZYJt9PJR+MyixcBzcOaTLLm2kBoPZOFU7oKgI8="

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,19 +6,17 @@ branches:
     - master
 env:
   global:
-  - secure: "HdkS3LONKdXYlW83TLwobYK+YIZBujkG8JuEyfSlueFEwYZ2Pk0GmQZP4Q5b50w4VqE1tnAvHmSg4q/ShP+NreH0EzBdnwFaUV+pts0mdwqk50g6JqQE8dbj2AU4wPrkungW9E1xWH6iuxQJbQnJCtgqGMfXHPpML5/0XLJtie7/T+1rTJE9zDTct+IRk1s4aYjEMWm5Bkm4A+BDYAEwfoeesgQ1Qj46+FSLVFnO28x0RkSy/Ucq1SBolTCxw6X4Q9cMCpmkQ5kQj3cdSf968WQJazECzzY0Ev9sv1NfZCYhV5nb9zlIt0CMbcbogUA+rBAg0Vw/TdMz3y8UM5b7CU9TG90WvB8psA++d26XOVRz42oBkXwh6rO/yUdAaDEzTRzgjE1ESOBJSpcr3pjSGWb6DJgW2lNW6JjmBGmOqSsmBHVa3VGAXlxvS/aUHU/LH/oC7YkNf2jhjl+M1fZwt+mQO5QhFBhS2BB+VnFPMPFpyJcwdZJI6DJzXPSj7LFdYtjI7F68+s2a7lgzVtSL3vXVq2cD+qQP4AjR7Ekd05+1SBHLvaCsktrZJ6lcmKQUwyTGYel7uzmL6et9vZ1eS5b3u5YSeKNmxwcJ0XPBduh1n+NQX1vtpNSgJX4dSplmFn3grO4ujDptyFoyC4Qc8OGQWTAav+m14+OcKPPUZCI="
+    - secure: "lN/1nBJvrLsBhDRJwoAKiu5Xv9dRyH7EJ4DC1AUgRfaz/2in8e9X8psluCxXiCkUqxJqjqIwp/IUWJyIgnUj1Tj8KT2dyR/wp68Q+tr3buRxGbZf9lAIirj44LB7ji5cxGKmuvJNY3M5hFaLoovquqacwB0FslnhssH/HpuSHMC2lyNXxnIduTLha/7AZAX7+xNTeRQ86cpVIh5/UJEhvqICdlywhsguAdeyyI/ZLRElLY07O3R9SJAaOgy95oDmSwq3IflIjBNhlxrWKYUUAkQFjM3HdwcmLbhP5aZAJWbrDRiAeXzJyqgvvo/oHS+AtSc8r68TvZ+O+H4d0XLbExrz4cFdXHKCJY/OuI6pwpXRWoXiPgEBpNodef5iGupU84ZxKiBGvSWEJNgGDSHLwUgVzEtOSPnvmeVGRHHi2hO9onOMKHPsJR8aHWg8VDcsf3kXIF7YVC2lvaO5Ubi9ESzjBoE3tQsQlcaHCOzYsXqI70DAH4lgZtabYRIWbFcbl+RSoNsrvh5HhMl17W0YM1a3+bXdF/Q926jFg506XDvYhyPy2DUoiwnSdtthxMJYYLTDSYjZDzykmCH0A2TM+iM2hJLP8LO/b7wLxj/lI2NhmRQzhI8pMhkBHa97kMH3eTX+QZYJt9PJR+MyixcBzcOaTLLm2kBoPZOFU7oKgI8="
 
 before_install:
-  - echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
-
-script: mvn clean package -DskipTests=true
+  - echo -n | openssl s_client -connect https://scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
 
 addons:
   coverity_scan:
     project:
-      name: lime-company/powerauth-push-server
-      description: Build submitted via Travis CI
-    notification_email: petr@wultra.com
-    build_command_prepend: mvn clean
-    build_command: mvn compile -DskipTests=true
-    branch_pattern: master
+      name: "wultra/powerauth-push-server"
+      description: "Build submitted via Travis CI"
+    notification_email: roman.strobl@wultra.com
+    build_command_prepend: "mvn clean"
+    build_command: "mvn compile -DskipTests=true"
+    branch_pattern: coverity_scan


### PR DESCRIPTION
Update of coverity scan configuration

I am moving coverity scan to a separate branch (as recommended by Coverity Scan). The service has frequent outages (e.g. last upgrade caused a 4-day outage, earlier the service was inaccessible for weeks), we don't want to show failing builds whenever coverity scan fails.