### PR TITLE
Fix #284: Deprecate crypto provider abstraction

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
         <jsp-api.version>2.0</jsp-api.version>
         <jstl.version>1.2.5</jstl.version>
         <lime.rest.version>1.1.0</lime.rest.version>
-        <powerauth.version>0.23.0</powerauth.version>
+        <powerauth.version>0.24.0-SNAPSHOT</powerauth.version>
         <pushy.version>0.13.10</pushy.version>
         <swagger.version>2.9.2</swagger.version>
         <unirest.version>1.4.9</unirest.version>

--- a/powerauth-push-server/src/test/java/io/getlime/push/shared/PushServerTestClientFactory.java
+++ b/powerauth-push-server/src/test/java/io/getlime/push/shared/PushServerTestClientFactory.java
@@ -1,8 +1,6 @@
 package io.getlime.push.shared;
 
 import io.getlime.push.client.PushServerClient;
-import io.getlime.security.powerauth.crypto.lib.config.PowerAuthConfiguration;
-import io.getlime.security.powerauth.provider.CryptoProviderUtilFactory;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -25,7 +23,6 @@ public class PushServerTestClientFactory {
 
     public PowerAuthTestClient createPowerAuthTestClient() throws Exception {
         Security.addProvider(new BouncyCastleProvider());
-        PowerAuthConfiguration.INSTANCE.setKeyConvertor(CryptoProviderUtilFactory.getCryptoProviderUtils());
 
         PowerAuthTestClient powerAuthTestClient = new PowerAuthTestClient();
         powerAuthTestClient.initializeClient(powerAuthServiceUrl);


### PR DESCRIPTION
This pull request removes the crypto provider abstraction and updates the PowerAuth version to `0.24.0-SNAPSHOT`.