### PR TITLE
Fix #334: Integrity check issues

### DIFF
--- a/powerauth-push-server/src/main/java/io/getlime/push/errorhandling/DataIntegrityError.java
+++ b/powerauth-push-server/src/main/java/io/getlime/push/errorhandling/DataIntegrityError.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.push.errorhandling;
+
+import io.getlime.core.rest.model.base.entity.Error;
+
+/**
+ * Exception for data integrity error.
+ *
+ * @author Roman Strobl, roman.strobl@wultracom
+ */
+public class DataIntegrityError extends Error {
+    public class Code extends Error.Code {
+        public static final String ERROR_DATA_INTEGRITY = "ERROR_DATA_INTEGRITY";
+
+        public Code() {
+        }
+    }
+}

--- a/powerauth-push-server/src/main/java/io/getlime/push/errorhandling/DefaultExceptionHandler.java
+++ b/powerauth-push-server/src/main/java/io/getlime/push/errorhandling/DefaultExceptionHandler.java
@@ -21,6 +21,7 @@ import io.getlime.core.rest.model.base.response.ErrorResponse;
 import io.getlime.push.errorhandling.exceptions.PushServerException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -41,7 +42,7 @@ public class DefaultExceptionHandler {
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)  // 500
     @ExceptionHandler(Throwable.class)
     @ResponseBody
-    public ErrorResponse handleConflict(Throwable t) {
+    public ErrorResponse handleUnexpectedError(Throwable t) {
         logger.error(t.getMessage(), t);
         return new ErrorResponse(Error.Code.ERROR_GENERIC, t);
     }
@@ -60,6 +61,14 @@ public class DefaultExceptionHandler {
     public ErrorResponse handleDatabaseNotFound(Exception e) {
         logger.error(e.getMessage(), e);
         return new ErrorResponse(DatabaseError.Code.ERROR_DATABASE, e);
+    }
+
+    @ResponseStatus(HttpStatus.CONFLICT) // 409
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    @ResponseBody
+    public ErrorResponse handleDataIntegrityViolationException(DataIntegrityViolationException e) {
+        logger.error(e.getMessage(), e);
+        return new ErrorResponse(DataIntegrityError.Code.ERROR_DATA_INTEGRITY, e);
     }
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)  // 400


### PR DESCRIPTION
The data integrity error is handled and a 409 - CONFLICT HTTP status is returned instead of a generic 500 error. The error is still logged, because the error should not occur when the client is correctly implemented, we still want to find out when the client sends duplicate requests.