### PR TITLE
Fix #373: Push server fails to start on Wildfly

### DIFF
--- a/powerauth-push-server/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/powerauth-push-server/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -4,6 +4,7 @@
 		<exclude-subsystems>
 			<!-- disable the logging subsystem because the application manages its own logging independently -->
 			<subsystem name="logging" />
+			<subsystem name="jaxrs" />
 		</exclude-subsystems>
 
 		<dependencies>


### PR DESCRIPTION
The JAX-RS subsystem of Wildfly ships with old version of Jackson libraries which are not compatible with current versions of Jackson used in Push Server. I tried to disable the Jackson modules individually, but it didn't help. After excluding the JAX-RS subsystem Push server starts on Wildfly without any issues.