### PR TITLE
Fix #447: Exclude log4j-api dependency

### DIFF
--- a/powerauth-push-client/pom.xml
+++ b/powerauth-push-client/pom.xml
@@ -27,6 +27,12 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
+            <exclusions>
+                <exclusion>
+                    <artifactId>log4j-to-slf4j</artifactId>
+                    <groupId>org.apache.logging.log4j</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Other Dependencies -->

--- a/powerauth-push-model/pom.xml
+++ b/powerauth-push-model/pom.xml
@@ -25,6 +25,12 @@
             <groupId>io.getlime.core</groupId>
             <artifactId>rest-client-base</artifactId>
             <version>${rest-base.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>log4j-to-slf4j</artifactId>
+                    <groupId>org.apache.logging.log4j</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.getlime.security</groupId>

--- a/powerauth-push-server/pom.xml
+++ b/powerauth-push-server/pom.xml
@@ -22,6 +22,12 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-batch</artifactId>
+            <exclusions>
+                <exclusion>
+                    <artifactId>log4j-to-slf4j</artifactId>
+                    <groupId>org.apache.logging.log4j</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
This change should resolve any future questions about the Log4J dependencies included in Spring logging.