### PR TITLE
Add missing push_campaign.timestamp_sent column to liquibase

### DIFF
--- a/docs/db/changelog/changesets/powerauth-push-server/1.4.x/20230321-init-db.xml
+++ b/docs/db/changelog/changesets/powerauth-push-server/1.4.x/20230321-init-db.xml
@@ -175,6 +175,7 @@
             <column name="timestamp_created" type="timestamp(6)">
                 <constraints nullable="false" />
             </column>
+            <column name="timestamp_sent" type="timestamp(6)" />
             <column name="timestamp_completed" type="timestamp(6)" />
         </createTable>
     </changeSet>


### PR DESCRIPTION
Follow-up to #595