### PR TITLE
Fix #661: Polish google-api-client and guava versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,10 +74,9 @@
         <powerauth-crypto.version>1.5.0-SNAPSHOT</powerauth-crypto.version>
 
         <!-- Library Versions -->
-        <guava.version>31.1-jre</guava.version>
         <pushy.version>0.15.2</pushy.version>
         <springdoc-openapi.version>1.6.14</springdoc-openapi.version>
-        <google-api-client.version>1.35.1</google-api-client.version>
+        <google-api-client.version>1.35.2</google-api-client.version>
         <firebase-admin.version>9.2.0</firebase-admin.version>
         <bc.version>1.76</bc.version>
         <logstash.version>7.4</logstash.version>

--- a/powerauth-push-server/pom.xml
+++ b/powerauth-push-server/pom.xml
@@ -131,11 +131,6 @@
 
         <!-- Other Dependencies -->
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>


### PR DESCRIPTION
- update google-api-client to 1.35.2
- drop explicit guava declaration