### PR TITLE
Fix #739: Warning: Using generated security password

### DIFF
--- a/powerauth-push-server/src/main/resources/application.properties
+++ b/powerauth-push-server/src/main/resources/application.properties
@@ -102,3 +102,5 @@ powerauth.service.correlation-header.value.validation-regexp=[a-zA-Z0-9\\-]{8,10
 #management.endpoints.web.exposure.include=health, prometheus
 #management.endpoint.prometheus.enabled=true
 #management.prometheus.metrics.export.enabled=true
+
+spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration


### PR DESCRIPTION
- Exclude `UserDetailsServiceAutoConfiguration`