### PR TITLE
Fix #824: Refactor BouncyCastle dependency

### DIFF
--- a/docs/Deploying-Wildfly.md
+++ b/docs/Deploying-Wildfly.md
@@ -88,10 +88,3 @@ powerauth.service.url=https://[host]:[port]/powerauth-java-server/rest
 ```
 
 Push Server Spring application uses the `ext` Spring profile which activates overriding of default properties by `application-ext.properties`.
-
-### Bouncy Castle Installation
-
-The Bouncy Castle module for JBoss / Wildfly needs to be enabled as a global module for Push Server.
-
-Follow the instructions in the [Installing Bouncy Castle](https://github.com/wultra/powerauth-server/blob/develop/docs/Installing-Bouncy-Castle.md) chapter of PowerAuth Server documentation.
-Note that the instructions differ based on Java version and application server type.

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,6 @@
         <pushy.version>0.15.4</pushy.version>
         <google-api-client.version>2.4.0</google-api-client.version>
         <firebase-admin.version>9.2.0</firebase-admin.version>
-        <bc.version>1.78.1</bc.version>
         <logstash.version>7.4</logstash.version>
 
         <!-- Documentation Dependencies -->

--- a/powerauth-push-server/pom.xml
+++ b/powerauth-push-server/pom.xml
@@ -200,12 +200,6 @@
             <version>${powerauth-restful-integration.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk18on</artifactId>
-            <version>${bc.version}</version>
-            <scope>test</scope>
-        </dependency>
 
         <!-- Documentation -->
         <dependency>


### PR DESCRIPTION
Use transient dependency from `powerauth-crypto` which is scope `test`.

- [x] Depends on https://github.com/wultra/powerauth-crypto/pull/606