### PR TITLE
Fix #861: SQL error after DB column escaping

### DIFF
--- a/docs-private/Developer-How-To-Start.md
+++ b/docs-private/Developer-How-To-Start.md
@@ -21,3 +21,22 @@ Others (like URL, username, password) depend on your environment.
 ```shell
 liquibase --changelog-file=./docs/db/changelog/changesets/powerauth-push-server/db.changelog-module.xml --url=jdbc:postgresql://localhost:5432/powerauth --username=powerauth status
 ``` 
+
+#### PostgreSQL
+
+```shell
+liquibase --changeLogFile=./docs/db/changelog/changesets/powerauth-push-server/db.changelog-module.xml --output-file=./docs/sql/postgresql/migration_1.7.0_1.8.0.sql updateSQL --url=offline:postgresql
+```
+
+#### Oracle
+
+```shell
+liquibase --changeLogFile=./docs/db/changelog/changesets/powerauth-push-server/db.changelog-module.xml --output-file=./docs/sql/oracle/migration_1.7.0_1.8.0.sql updateSQL --url=offline:oracle
+```
+
+
+#### MSSQL
+
+```shell
+liquibase --changeLogFile=./docs/db/changelog/changesets/powerauth-push-server/db.changelog-module.xml --output-file=./docs/sql/mssql/migration_1.7.0_1.8.0.sql updateSQL --url=offline:mssql
+```

--- a/docs-private/Developer-How-To-Start.md
+++ b/docs-private/Developer-How-To-Start.md
@@ -22,6 +22,8 @@ Others (like URL, username, password) depend on your environment.
 liquibase --changelog-file=./docs/db/changelog/changesets/powerauth-push-server/db.changelog-module.xml --url=jdbc:postgresql://localhost:5432/powerauth --username=powerauth status
 ``` 
 
+To generate SQL script run following command:
+
 #### PostgreSQL
 
 ```shell

--- a/docs/Migration-Instructions.md
+++ b/docs/Migration-Instructions.md
@@ -2,6 +2,7 @@
 
 This page contains PowerAuth Push Server migration instructions.
 
+- [PowerAuth Push Server 1.8.0](./PowerAuth-Push-Server-1.8.0.md)
 - [PowerAuth Push Server 1.7.0](./PowerAuth-Push-Server-1.7.0.md)
 - [PowerAuth Push Server 1.6.0](./PowerAuth-Push-Server-1.6.0.md)
 - [PowerAuth Push Server 1.5.0](./PowerAuth-Push-Server-1.5.0.md)

--- a/docs/PowerAuth-Push-Server-1.8.0.md
+++ b/docs/PowerAuth-Push-Server-1.8.0.md
@@ -1,0 +1,16 @@
+# Migration from 1.7.x to 1.8.x
+
+This guide contains instructions for migration from PowerAuth Push Server version `1.7.x` to version `1.8.x`.
+
+
+## Database Changes
+
+For convenience, you can use liquibase for your database migration.
+
+**Important: Upgrading to version 1.8.x includes column renaming, resulting in incompatible changes. Therefore, ensure all Push Server nodes are upgraded simultaneously during a scheduled service window.**
+
+If you prefer to make manual DB schema changes, please use the following SQL scripts:
+
+- [PostgreSQL script](./sql/postgresql/migration_1.7.0_1.8.0.sql)
+- [Oracle script](./sql/oracle/migration_1.7.0_1.8.0.sql)
+- [MSSQL script](./sql/mssql/migration_1.7.0_1.8.0.sql)

--- a/docs/PowerAuth-Push-Server-1.8.0.md
+++ b/docs/PowerAuth-Push-Server-1.8.0.md
@@ -7,7 +7,7 @@ This guide contains instructions for migration from PowerAuth Push Server versio
 
 For convenience, you can use liquibase for your database migration.
 
-**Important: Upgrading to version 1.8.x includes column renaming, resulting in incompatible changes. Therefore, ensure all Push Server nodes are upgraded simultaneously during a scheduled service window.**
+**Important: Upgrading to version 1.8.x includes database column renaming required for the Inbox functionality, resulting in incompatible changes. Therefore, ensure all Push Server nodes are upgraded simultaneously during a scheduled service window.**
 
 If you prefer to make manual DB schema changes, please use the following SQL scripts:
 

--- a/docs/db/changelog/changesets/powerauth-push-server/1.8.x/20240708-column-renaming-keywords.xml
+++ b/docs/db/changelog/changesets/powerauth-push-server/1.8.x/20240708-column-renaming-keywords.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd">
+
+    <changeSet id="1" logicalFilePath="powerauth-push-server/1.8.x/20240708-column-renaming-keywords.xml" author="Roman Strobl">
+        <preConditions onFail="MARK_RAN">
+            <and>
+                <tableExists tableName="push_inbox"/>
+                <columnExists tableName="push_inbox" columnName="read"/>
+                <columnExists tableName="push_inbox" columnName="type"/>
+            </and>
+        </preConditions>
+        <comment>Rename columns read to is_read and type to message_type in push_inbox table</comment>
+        <renameColumn tableName="push_inbox" oldColumnName="read" newColumnName="is_read" columnDataType="boolean"/>
+        <renameColumn tableName="push_inbox" oldColumnName="type" newColumnName="message_type" columnDataType="varchar(32)"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/docs/db/changelog/changesets/powerauth-push-server/1.8.x/db.changelog-version.xml
+++ b/docs/db/changelog/changesets/powerauth-push-server/1.8.x/db.changelog-version.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd">
+
+    <include file="20240708-column-renaming-keywords.xml" relativeToChangelogFile="true" />
+
+</databaseChangeLog>

--- a/docs/db/changelog/changesets/powerauth-push-server/db.changelog-module.xml
+++ b/docs/db/changelog/changesets/powerauth-push-server/db.changelog-module.xml
@@ -10,5 +10,6 @@
     <include file="1.4.x/db.changelog-version.xml" relativeToChangelogFile="true" />
     <include file="1.5.x/db.changelog-version.xml" relativeToChangelogFile="true" />
     <include file="1.7.x/db.changelog-version.xml" relativeToChangelogFile="true" />
+    <include file="1.8.x/db.changelog-version.xml" relativeToChangelogFile="true" />
 
 </databaseChangeLog>

--- a/docs/sql/mssql/create_push_server_schema.sql
+++ b/docs/sql/mssql/create_push_server_schema.sql
@@ -1,0 +1,148 @@
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::1::Lubos Racansky
+-- Create a new sequence push_credentials_seq
+CREATE SEQUENCE push_credentials_seq START WITH 1 INCREMENT BY 1;
+GO
+
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::2::Lubos Racansky
+-- Create a new sequence sequence push_device_registration_seq
+CREATE SEQUENCE push_device_registration_seq START WITH 1 INCREMENT BY 1;
+GO
+
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::3::Lubos Racansky
+-- Create a new sequence sequence push_message_seq
+CREATE SEQUENCE push_message_seq START WITH 1 INCREMENT BY 1;
+GO
+
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::4::Lubos Racansky
+-- Create a new sequence sequence push_campaign_seq
+CREATE SEQUENCE push_campaign_seq START WITH 1 INCREMENT BY 1;
+GO
+
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::5::Lubos Racansky
+-- Create a new sequence sequence push_campaign_user_seq
+CREATE SEQUENCE push_campaign_user_seq START WITH 1 INCREMENT BY 1;
+GO
+
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::6::Lubos Racansky
+-- Create a new sequence sequence push_inbox_seq
+CREATE SEQUENCE push_inbox_seq START WITH 1 INCREMENT BY 1;
+GO
+
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::7::Lubos Racansky
+-- Create a new sequence push_app_credentials
+CREATE TABLE push_app_credentials (id int NOT NULL, app_id varchar(255) NOT NULL, ios_key_id varchar(255), ios_private_key varbinary(MAX), ios_team_id varchar(255), ios_bundle varchar(255), ios_environment varchar(32), android_private_key varbinary(MAX), android_project_id varchar(255), CONSTRAINT PK_PUSH_APP_CREDENTIALS PRIMARY KEY (id));
+GO
+
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::8::Lubos Racansky
+-- Create a new sequence push_device_registration
+CREATE TABLE push_device_registration (id int NOT NULL, activation_id varchar(37), user_id varchar(255), app_id int NOT NULL, platform varchar(255) NOT NULL, push_token varchar(255) NOT NULL, timestamp_last_registered datetime2(6) NOT NULL, is_active bit, CONSTRAINT PK_PUSH_DEVICE_REGISTRATION PRIMARY KEY (id));
+GO
+
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::9::Lubos Racansky
+-- Create a new sequence push_message
+CREATE TABLE push_message (id int NOT NULL, device_registration_id int NOT NULL, user_id varchar(255) NOT NULL, activation_id varchar(37), is_silent bit CONSTRAINT DF_push_message_is_silent DEFAULT 0 NOT NULL, is_personal bit CONSTRAINT DF_push_message_is_personal DEFAULT 0 NOT NULL, message_body varchar(2048) NOT NULL, timestamp_created datetime2(6) NOT NULL, status int NOT NULL, CONSTRAINT PK_PUSH_MESSAGE PRIMARY KEY (id));
+GO
+
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::10::Lubos Racansky
+-- Create a new sequence push_campaign
+CREATE TABLE push_campaign (id int NOT NULL, app_id int NOT NULL, message varchar(4000) NOT NULL, is_sent bit CONSTRAINT DF_push_campaign_is_sent DEFAULT 0 NOT NULL, timestamp_created datetime2(6) NOT NULL, timestamp_sent datetime2(6), timestamp_completed datetime2(6), CONSTRAINT PK_PUSH_CAMPAIGN PRIMARY KEY (id));
+GO
+
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::11::Lubos Racansky
+-- Create a new sequence push_campaign_user
+CREATE TABLE push_campaign_user (id int NOT NULL, campaign_id int NOT NULL, user_id varchar(255) NOT NULL, timestamp_created datetime2(6) NOT NULL, CONSTRAINT PK_PUSH_CAMPAIGN_USER PRIMARY KEY (id));
+GO
+
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::12::Lubos Racansky
+-- Create a new table push_inbox
+CREATE TABLE push_inbox (id int NOT NULL, inbox_id varchar(37) NOT NULL, user_id varchar(255) NOT NULL, type varchar(32) NOT NULL, subject varchar (max) NOT NULL, summary varchar (max) NOT NULL, body varchar (max) NOT NULL, [read] bit CONSTRAINT DF_push_inbox_read DEFAULT 0 NOT NULL, timestamp_created datetime2 NOT NULL, timestamp_read datetime2, CONSTRAINT PK_PUSH_INBOX PRIMARY KEY (id));
+GO
+
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::13::Lubos Racansky
+-- Create a new sequence push_inbox_app
+CREATE TABLE push_inbox_app (app_credentials_id int NOT NULL, inbox_id int NOT NULL, CONSTRAINT PK_PUSH_INBOX_APP PRIMARY KEY (app_credentials_id, inbox_id));
+GO
+
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::14::Lubos Racansky
+-- Create a new unique index on push_app_credentials(app_id)
+CREATE UNIQUE NONCLUSTERED INDEX push_app_cred_app ON push_app_credentials(app_id);
+GO
+
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::15::Lubos Racansky
+-- Create a new index on push_device_registration(app_id, push_token)
+CREATE NONCLUSTERED INDEX push_device_app_token ON push_device_registration(app_id, push_token);
+GO
+
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::16::Lubos Racansky
+-- Create a new index on push_device_registration(user_id, app_id)
+CREATE NONCLUSTERED INDEX push_device_user_app ON push_device_registration(user_id, app_id);
+GO
+
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::17::Lubos Racansky
+-- Create a new unique index on push_device_registration(activation_id)
+CREATE UNIQUE NONCLUSTERED INDEX push_device_activation ON push_device_registration(activation_id);
+GO
+
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::18::Lubos Racansky
+-- Create a new unique index on push_device_registration(activation_id, push_token)
+CREATE UNIQUE NONCLUSTERED INDEX push_device_activation_token ON push_device_registration(activation_id, push_token);
+GO
+
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::19::Lubos Racansky
+-- Create a new index on push_message(status)
+CREATE NONCLUSTERED INDEX push_message_status ON push_message(status);
+GO
+
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::20::Lubos Racansky
+-- Create a new index on push_campaign(is_sent)
+CREATE NONCLUSTERED INDEX push_campaign_sent ON push_campaign(is_sent);
+GO
+
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::21::Lubos Racansky
+-- Create a new index on push_campaign_user(campaign_id, user_id)
+CREATE NONCLUSTERED INDEX push_campaign_user_campaign ON push_campaign_user(campaign_id, user_id);
+GO
+
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::22::Lubos Racansky
+-- Create a new index on push_campaign_user(user_id)
+CREATE NONCLUSTERED INDEX push_campaign_user_detail ON push_campaign_user(user_id);
+GO
+
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::23::Lubos Racansky
+-- Create a new index on push_inbox(inbox_id)
+CREATE NONCLUSTERED INDEX push_inbox_id ON push_inbox(inbox_id);
+GO
+
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::24::Lubos Racansky
+-- Create a new index on push_inbox(user_id)
+CREATE NONCLUSTERED INDEX push_inbox_user ON push_inbox(user_id);
+GO
+
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::25::Lubos Racansky
+-- Create a new index on push_inbox(user_id, read)
+CREATE NONCLUSTERED INDEX push_inbox_user_read ON push_inbox(user_id, [read]);
+GO
+
+-- Changeset powerauth-push-server/1.4.x/20230322-add-tag-1.4.0.xml::1::Lubos Racansky
+-- Changeset powerauth-push-server/1.5.x/20230905-add-tag-1.5.0.xml::1::Lubos Racansky
+-- Changeset powerauth-push-server/1.7.x/20240119-push_app_credentials-hms.xml::1::Lubos Racansky
+-- Add hms_project_id, hms_client_id, and hms_client_secret columns to push_app_credentials
+ALTER TABLE push_app_credentials ADD hms_project_id varchar(255);
+GO
+
+ALTER TABLE push_app_credentials ADD hms_client_id varchar(255);
+GO
+
+ALTER TABLE push_app_credentials ADD hms_client_secret varchar(255);
+GO
+
+IF EXISTS(  SELECT extended_properties.value FROM sys.extended_properties WHERE major_id = OBJECT_ID('dbo.push_app_credentials') AND name = N'MS_DESCRIPTION' AND minor_id = ( SELECT column_id FROM sys.columns WHERE name = 'hms_project_id' AND object_id = OBJECT_ID('dbo.push_app_credentials')) ) BEGIN  EXEC sys.sp_updateextendedproperty @name = N'MS_Description' , @value = N'Project ID defined in Huawei AppGallery Connect.' , @level0type = N'SCHEMA' , @level0name = N'dbo' , @level1type = N'TABLE' , @level1name = N'push_app_credentials' , @level2type = N'COLUMN' , @level2name = N'hms_project_id' END  ELSE  BEGIN  EXEC sys.sp_addextendedproperty @name = N'MS_Description' , @value = N'Project ID defined in Huawei AppGallery Connect.' , @level0type = N'SCHEMA' , @level0name = N'dbo' , @level1type = N'TABLE' , @level1name = N'push_app_credentials' , @level2type = N'COLUMN' , @level2name = N'hms_project_id' END;
+GO
+
+IF EXISTS(  SELECT extended_properties.value FROM sys.extended_properties WHERE major_id = OBJECT_ID('dbo.push_app_credentials') AND name = N'MS_DESCRIPTION' AND minor_id = ( SELECT column_id FROM sys.columns WHERE name = 'hms_client_id' AND object_id = OBJECT_ID('dbo.push_app_credentials')) ) BEGIN  EXEC sys.sp_updateextendedproperty @name = N'MS_Description' , @value = N'Huawei OAuth 2.0 Client ID.' , @level0type = N'SCHEMA' , @level0name = N'dbo' , @level1type = N'TABLE' , @level1name = N'push_app_credentials' , @level2type = N'COLUMN' , @level2name = N'hms_client_id' END  ELSE  BEGIN  EXEC sys.sp_addextendedproperty @name = N'MS_Description' , @value = N'Huawei OAuth 2.0 Client ID.' , @level0type = N'SCHEMA' , @level0name = N'dbo' , @level1type = N'TABLE' , @level1name = N'push_app_credentials' , @level2type = N'COLUMN' , @level2name = N'hms_client_id' END;
+GO
+
+IF EXISTS(  SELECT extended_properties.value FROM sys.extended_properties WHERE major_id = OBJECT_ID('dbo.push_app_credentials') AND name = N'MS_DESCRIPTION' AND minor_id = ( SELECT column_id FROM sys.columns WHERE name = 'hms_client_secret' AND object_id = OBJECT_ID('dbo.push_app_credentials')) ) BEGIN  EXEC sys.sp_updateextendedproperty @name = N'MS_Description' , @value = N'Huawei OAuth 2.0 Client Secret.' , @level0type = N'SCHEMA' , @level0name = N'dbo' , @level1type = N'TABLE' , @level1name = N'push_app_credentials' , @level2type = N'COLUMN' , @level2name = N'hms_client_secret' END  ELSE  BEGIN  EXEC sys.sp_addextendedproperty @name = N'MS_Description' , @value = N'Huawei OAuth 2.0 Client Secret.' , @level0type = N'SCHEMA' , @level0name = N'dbo' , @level1type = N'TABLE' , @level1name = N'push_app_credentials' , @level2type = N'COLUMN' , @level2name = N'hms_client_secret' END;
+GO
+
+-- Changeset powerauth-push-server/1.7.x/20240222-add-tag-1.7.0.xml::1::Lubos Racansky

--- a/docs/sql/mssql/migration_1.7.0_1.8.0.sql
+++ b/docs/sql/mssql/migration_1.7.0_1.8.0.sql
@@ -1,0 +1,7 @@
+-- Changeset powerauth-push-server/1.8.x/20240708-column-renaming-keywords.xml::1::Roman Strobl
+-- Rename columns read to is_read and type to message_type in push_inbox table
+exec sp_rename 'push_inbox.[read]', 'is_read', 'COLUMN';
+GO
+
+exec sp_rename 'push_inbox.type', 'message_type', 'COLUMN';
+GO

--- a/docs/sql/oracle/create_push_server_schema.sql
+++ b/docs/sql/oracle/create_push_server_schema.sql
@@ -1,103 +1,117 @@
-CREATE SEQUENCE PUSH_CREDENTIALS_SEQ START WITH 1 INCREMENT BY 1;
-CREATE SEQUENCE PUSH_DEVICE_REGISTRATION_SEQ START WITH 1 INCREMENT BY 1;
-CREATE SEQUENCE PUSH_MESSAGE_SEQ START WITH 1 INCREMENT BY 1;
-CREATE SEQUENCE PUSH_CAMPAIGN_SEQ START WITH 1 INCREMENT BY 1;
-CREATE SEQUENCE PUSH_CAMPAIGN_USER_SEQ START WITH 1 INCREMENT BY 1;
-CREATE SEQUENCE PUSH_INBOX_SEQ START WITH 1 INCREMENT BY 1;
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::1::Lubos Racansky
+-- Create a new sequence push_credentials_seq
+CREATE SEQUENCE push_credentials_seq START WITH 1 INCREMENT BY 1 CACHE 20;
 
-CREATE TABLE PUSH_APP_CREDENTIALS
-(
-    ID NUMBER(19) PRIMARY KEY NOT NULL,
-    APP_ID VARCHAR2(255) NOT NULL,
-    IOS_KEY_ID VARCHAR2(255 CHAR),
-    IOS_PRIVATE_KEY BLOB,
-    IOS_TEAM_ID VARCHAR2(255 CHAR),
-    IOS_BUNDLE VARCHAR2(255 CHAR),
-    IOS_ENVIRONMENT VARCHAR2(32 CHAR),
-    ANDROID_PRIVATE_KEY BLOB,
-    ANDROID_PROJECT_ID VARCHAR2(255 CHAR)
-);
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::2::Lubos Racansky
+-- Create a new sequence sequence push_device_registration_seq
+CREATE SEQUENCE push_device_registration_seq START WITH 1 INCREMENT BY 1 CACHE 20;
 
-CREATE TABLE PUSH_DEVICE_REGISTRATION
-(
-    ID NUMBER(19) PRIMARY KEY NOT NULL,
-    ACTIVATION_ID VARCHAR2(37 CHAR),
-    USER_ID VARCHAR2(255 CHAR),
-    APP_ID NUMBER(19) NOT NULL,
-    PLATFORM VARCHAR2(255 CHAR) NOT NULL,
-    PUSH_TOKEN VARCHAR2(255 CHAR) NOT NULL,
-    TIMESTAMP_LAST_REGISTERED TIMESTAMP(6) NOT NULL,
-    IS_ACTIVE NUMBER(1)
-);
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::3::Lubos Racansky
+-- Create a new sequence sequence push_message_seq
+CREATE SEQUENCE push_message_seq START WITH 1 INCREMENT BY 1 CACHE 20;
 
-CREATE TABLE PUSH_MESSAGE
-(
-    ID NUMBER(19) PRIMARY KEY NOT NULL,
-    DEVICE_REGISTRATION_ID NUMBER(19) NOT NULL,
-    USER_ID VARCHAR2(255 CHAR) NOT NULL,
-    ACTIVATION_ID VARCHAR2(37 CHAR),
-    IS_SILENT NUMBER(1) NOT NULL,
-    IS_PERSONAL NUMBER(1) NOT NULL,
-    MESSAGE_BODY VARCHAR2(2048 CHAR) NOT NULL,
-    TIMESTAMP_CREATED TIMESTAMP(6) NOT NULL,
-    STATUS NUMBER(10) NOT NULL
-);
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::4::Lubos Racansky
+-- Create a new sequence sequence push_campaign_seq
+CREATE SEQUENCE push_campaign_seq START WITH 1 INCREMENT BY 1 CACHE 20;
 
-CREATE TABLE PUSH_CAMPAIGN (
-  ID NUMBER(19) PRIMARY KEY NOT NULL,
-  APP_ID NUMBER(19) NOT NULL,
-  MESSAGE VARCHAR2(4000 CHAR) NOT NULL,
-  IS_SENT NUMBER(1) DEFAULT 0,
-  TIMESTAMP_CREATED TIMESTAMP(6) NOT NULL,
-  TIMESTAMP_SENT  TIMESTAMP(6),
-  TIMESTAMP_COMPLETED  TIMESTAMP(6)
-);
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::5::Lubos Racansky
+-- Create a new sequence sequence push_campaign_user_seq
+CREATE SEQUENCE push_campaign_user_seq START WITH 1 INCREMENT BY 1 CACHE 20;
 
-CREATE TABLE PUSH_CAMPAIGN_USER (
-  ID NUMBER(19) PRIMARY KEY NOT NULL,
-  CAMPAIGN_ID NUMBER(19) NOT NULL,
-  USER_ID VARCHAR2(255 CHAR) NOT NULL,
-  TIMESTAMP_CREATED TIMESTAMP(6) NOT NULL
-);
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::6::Lubos Racansky
+-- Create a new sequence sequence push_inbox_seq
+CREATE SEQUENCE push_inbox_seq START WITH 1 INCREMENT BY 1 CACHE 20;
 
-CREATE TABLE PUSH_INBOX (
-  ID NUMBER(19) PRIMARY KEY NOT NULL,
-  INBOX_ID VARCHAR2(37 CHAR) NOT NULL,
-  USER_ID VARCHAR2(255 CHAR) NOT NULL,
-  TYPE VARCHAR2(32 CHAR) NOT NULL,
-  SUBJECT VARCHAR2(4000 CHAR) NOT NULL,
-  SUMMARY VARCHAR2(4000 CHAR) NOT NULL,
-  BODY CLOB NOT NULL,
-  READ NUMBER(1) DEFAULT 0 NOT NULL,
-  TIMESTAMP_CREATED TIMESTAMP(6) NOT NULL,
-  TIMESTAMP_READ TIMESTAMP(6)
-);
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::7::Lubos Racansky
+-- Create a new sequence push_app_credentials
+CREATE TABLE push_app_credentials (id INTEGER NOT NULL, app_id VARCHAR2(255) NOT NULL, ios_key_id VARCHAR2(255), ios_private_key BLOB, ios_team_id VARCHAR2(255), ios_bundle VARCHAR2(255), ios_environment VARCHAR2(32), android_private_key BLOB, android_project_id VARCHAR2(255), CONSTRAINT PK_PUSH_APP_CREDENTIALS PRIMARY KEY (id));
 
--- Create table for assignment of inbox messages to apps
-CREATE TABLE PUSH_INBOX_APP (
-  APP_CREDENTIALS_ID NUMBER(19) NOT NULL,
-  INBOX_ID           NUMBER(19) NOT NULL,
-  CONSTRAINT PUSH_INBOX_APP_PK PRIMARY KEY (INBOX_ID, APP_CREDENTIALS_ID)
-);
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::8::Lubos Racansky
+-- Create a new sequence push_device_registration
+CREATE TABLE push_device_registration (id INTEGER NOT NULL, activation_id VARCHAR2(37), user_id VARCHAR2(255), app_id INTEGER NOT NULL, platform VARCHAR2(255) NOT NULL, push_token VARCHAR2(255) NOT NULL, timestamp_last_registered TIMESTAMP(6) NOT NULL, is_active BOOLEAN, CONSTRAINT PK_PUSH_DEVICE_REGISTRATION PRIMARY KEY (id));
 
----
---- Indexes for better performance.
----
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::9::Lubos Racansky
+-- Create a new sequence push_message
+CREATE TABLE push_message (id INTEGER NOT NULL, device_registration_id INTEGER NOT NULL, user_id VARCHAR2(255) NOT NULL, activation_id VARCHAR2(37), is_silent BOOLEAN DEFAULT 0 NOT NULL, is_personal BOOLEAN DEFAULT 0 NOT NULL, message_body VARCHAR2(2048) NOT NULL, timestamp_created TIMESTAMP(6) NOT NULL, status INTEGER NOT NULL, CONSTRAINT PK_PUSH_MESSAGE PRIMARY KEY (id));
 
-CREATE UNIQUE INDEX PUSH_APP_CRED_APP ON PUSH_APP_CREDENTIALS(APP_ID);
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::10::Lubos Racansky
+-- Create a new sequence push_campaign
+CREATE TABLE push_campaign (id INTEGER NOT NULL, app_id INTEGER NOT NULL, message VARCHAR2(4000) NOT NULL, is_sent BOOLEAN DEFAULT 0 NOT NULL, timestamp_created TIMESTAMP(6) NOT NULL, timestamp_sent TIMESTAMP(6), timestamp_completed TIMESTAMP(6), CONSTRAINT PK_PUSH_CAMPAIGN PRIMARY KEY (id));
 
-CREATE INDEX PUSH_DEVICE_APP_TOKEN ON PUSH_DEVICE_REGISTRATION(APP_ID, PUSH_TOKEN);
-CREATE INDEX PUSH_DEVICE_USER_APP ON PUSH_DEVICE_REGISTRATION(USER_ID, APP_ID);
-CREATE UNIQUE INDEX PUSH_DEVICE_ACTIVATION ON PUSH_DEVICE_REGISTRATION(ACTIVATION_ID);
-CREATE UNIQUE INDEX PUSH_DEVICE_ACTIVATION_TOKEN ON PUSH_DEVICE_REGISTRATION(ACTIVATION_ID, PUSH_TOKEN);
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::11::Lubos Racansky
+-- Create a new sequence push_campaign_user
+CREATE TABLE push_campaign_user (id INTEGER NOT NULL, campaign_id INTEGER NOT NULL, user_id VARCHAR2(255) NOT NULL, timestamp_created TIMESTAMP(6) NOT NULL, CONSTRAINT PK_PUSH_CAMPAIGN_USER PRIMARY KEY (id));
 
-CREATE INDEX PUSH_MESSAGE_STATUS ON PUSH_MESSAGE(STATUS);
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::12::Lubos Racansky
+-- Create a new table push_inbox
+CREATE TABLE push_inbox (id INTEGER NOT NULL, inbox_id VARCHAR2(37) NOT NULL, user_id VARCHAR2(255) NOT NULL, type VARCHAR2(32) NOT NULL, subject CLOB NOT NULL, summary CLOB NOT NULL, body CLOB NOT NULL, read BOOLEAN DEFAULT 0 NOT NULL, timestamp_created TIMESTAMP NOT NULL, timestamp_read TIMESTAMP, CONSTRAINT PK_PUSH_INBOX PRIMARY KEY (id));
 
-CREATE INDEX PUSH_CAMPAIGN_SENT ON PUSH_CAMPAIGN(IS_SENT);
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::13::Lubos Racansky
+-- Create a new sequence push_inbox_app
+CREATE TABLE push_inbox_app (app_credentials_id INTEGER NOT NULL, inbox_id INTEGER NOT NULL, CONSTRAINT PK_PUSH_INBOX_APP PRIMARY KEY (app_credentials_id, inbox_id));
 
-CREATE INDEX PUSH_CAMPAIGN_USER_CAMPAIGN ON PUSH_CAMPAIGN_USER(CAMPAIGN_ID, USER_ID);
-CREATE INDEX PUSH_CAMPAIGN_USER_DETAIL ON PUSH_CAMPAIGN_USER(USER_ID);
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::14::Lubos Racansky
+-- Create a new unique index on push_app_credentials(app_id)
+CREATE UNIQUE INDEX push_app_cred_app ON push_app_credentials(app_id);
 
-CREATE INDEX PUSH_INBOX_ID ON PUSH_INBOX(INBOX_ID);
-CREATE INDEX PUSH_INBOX_USER ON PUSH_INBOX(USER_ID);
-CREATE INDEX PUSH_INBOX_USER_READ ON PUSH_INBOX(USER_ID, READ);
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::15::Lubos Racansky
+-- Create a new index on push_device_registration(app_id, push_token)
+CREATE INDEX push_device_app_token ON push_device_registration(app_id, push_token);
+
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::16::Lubos Racansky
+-- Create a new index on push_device_registration(user_id, app_id)
+CREATE INDEX push_device_user_app ON push_device_registration(user_id, app_id);
+
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::17::Lubos Racansky
+-- Create a new unique index on push_device_registration(activation_id)
+CREATE UNIQUE INDEX push_device_activation ON push_device_registration(activation_id);
+
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::18::Lubos Racansky
+-- Create a new unique index on push_device_registration(activation_id, push_token)
+CREATE UNIQUE INDEX push_device_activation_token ON push_device_registration(activation_id, push_token);
+
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::19::Lubos Racansky
+-- Create a new index on push_message(status)
+CREATE INDEX push_message_status ON push_message(status);
+
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::20::Lubos Racansky
+-- Create a new index on push_campaign(is_sent)
+CREATE INDEX push_campaign_sent ON push_campaign(is_sent);
+
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::21::Lubos Racansky
+-- Create a new index on push_campaign_user(campaign_id, user_id)
+CREATE INDEX push_campaign_user_campaign ON push_campaign_user(campaign_id, user_id);
+
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::22::Lubos Racansky
+-- Create a new index on push_campaign_user(user_id)
+CREATE INDEX push_campaign_user_detail ON push_campaign_user(user_id);
+
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::23::Lubos Racansky
+-- Create a new index on push_inbox(inbox_id)
+CREATE INDEX push_inbox_id ON push_inbox(inbox_id);
+
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::24::Lubos Racansky
+-- Create a new index on push_inbox(user_id)
+CREATE INDEX push_inbox_user ON push_inbox(user_id);
+
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::25::Lubos Racansky
+-- Create a new index on push_inbox(user_id, read)
+CREATE INDEX push_inbox_user_read ON push_inbox(user_id, read);
+
+-- Changeset powerauth-push-server/1.4.x/20230322-add-tag-1.4.0.xml::1::Lubos Racansky
+-- Changeset powerauth-push-server/1.5.x/20230905-add-tag-1.5.0.xml::1::Lubos Racansky
+-- Changeset powerauth-push-server/1.7.x/20240119-push_app_credentials-hms.xml::1::Lubos Racansky
+-- Add hms_project_id, hms_client_id, and hms_client_secret columns to push_app_credentials
+ALTER TABLE push_app_credentials ADD hms_project_id VARCHAR2(255);
+
+ALTER TABLE push_app_credentials ADD hms_client_id VARCHAR2(255);
+
+ALTER TABLE push_app_credentials ADD hms_client_secret VARCHAR2(255);
+
+COMMENT ON COLUMN push_app_credentials.hms_project_id IS 'Project ID defined in Huawei AppGallery Connect.';
+
+COMMENT ON COLUMN push_app_credentials.hms_client_id IS 'Huawei OAuth 2.0 Client ID.';
+
+COMMENT ON COLUMN push_app_credentials.hms_client_secret IS 'Huawei OAuth 2.0 Client Secret.';
+
+-- Changeset powerauth-push-server/1.7.x/20240222-add-tag-1.7.0.xml::1::Lubos Racansky

--- a/docs/sql/oracle/migration_1.7.0_1.8.0.sql
+++ b/docs/sql/oracle/migration_1.7.0_1.8.0.sql
@@ -1,0 +1,5 @@
+-- Changeset powerauth-push-server/1.8.x/20240708-column-renaming-keywords.xml::1::Roman Strobl
+-- Rename columns read to is_read and type to message_type in push_inbox table
+ALTER TABLE push_inbox RENAME COLUMN read TO is_read;
+
+ALTER TABLE push_inbox RENAME COLUMN type TO message_type;

--- a/docs/sql/postgresql/create_push_server_schema.sql
+++ b/docs/sql/postgresql/create_push_server_schema.sql
@@ -1,122 +1,117 @@
----
---- DB Sequences
----
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::1::Lubos Racansky
+-- Create a new sequence push_credentials_seq
+CREATE SEQUENCE  IF NOT EXISTS push_credentials_seq START WITH 1 INCREMENT BY 1 CACHE 20;
 
-CREATE SEQUENCE push_credentials_seq;
-CREATE SEQUENCE push_device_registration_seq;
-CREATE SEQUENCE push_message_seq;
-CREATE SEQUENCE push_campaign_seq;
-CREATE SEQUENCE push_campaign_user_seq;
-CREATE SEQUENCE push_inbox_seq;
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::2::Lubos Racansky
+-- Create a new sequence sequence push_device_registration_seq
+CREATE SEQUENCE  IF NOT EXISTS push_device_registration_seq START WITH 1 INCREMENT BY 1 CACHE 20;
 
----
---- DB Tables
----
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::3::Lubos Racansky
+-- Create a new sequence sequence push_message_seq
+CREATE SEQUENCE  IF NOT EXISTS push_message_seq START WITH 1 INCREMENT BY 1 CACHE 20;
 
--- Create table for application credentials used for APNS and FCM
-CREATE TABLE push_app_credentials (
-	id INTEGER NOT NULL CONSTRAINT push_app_credentials_pkey PRIMARY KEY,
-	app_id VARCHAR(255) NOT NULL,
-	ios_key_id VARCHAR(255),
-	ios_private_key BYTEA,
-	ios_team_id VARCHAR(255),
-	ios_bundle VARCHAR(255),
-	ios_environment VARCHAR(32),
-	android_private_key BYTEA,
-	android_project_id VARCHAR(255)
-);
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::4::Lubos Racansky
+-- Create a new sequence sequence push_campaign_seq
+CREATE SEQUENCE  IF NOT EXISTS push_campaign_seq START WITH 1 INCREMENT BY 1 CACHE 20;
 
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::5::Lubos Racansky
+-- Create a new sequence sequence push_campaign_user_seq
+CREATE SEQUENCE  IF NOT EXISTS push_campaign_user_seq START WITH 1 INCREMENT BY 1 CACHE 20;
 
--- Create table for registered devices
-CREATE TABLE push_device_registration (
-	id INTEGER NOT NULL CONSTRAINT push_device_registration_pkey PRIMARY KEY,
-	activation_id VARCHAR(37),
-	user_id VARCHAR(255),
-	app_id INTEGER NOT NULL,
-	platform VARCHAR(255) NOT NULL,
-	push_token VARCHAR(255) NOT NULL,
-	timestamp_last_registered TIMESTAMP(6) NOT NULL,
-	is_active BOOLEAN
-);
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::6::Lubos Racansky
+-- Create a new sequence sequence push_inbox_seq
+CREATE SEQUENCE  IF NOT EXISTS push_inbox_seq START WITH 1 INCREMENT BY 1 CACHE 20;
 
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::7::Lubos Racansky
+-- Create a new sequence push_app_credentials
+CREATE TABLE push_app_credentials (id INTEGER NOT NULL, app_id VARCHAR(255) NOT NULL, ios_key_id VARCHAR(255), ios_private_key BYTEA, ios_team_id VARCHAR(255), ios_bundle VARCHAR(255), ios_environment VARCHAR(32), android_private_key BYTEA, android_project_id VARCHAR(255), CONSTRAINT push_app_credentials_pkey PRIMARY KEY (id));
 
--- Create table for optional auditing of sent push messages
-CREATE TABLE push_message (
-	id INTEGER NOT NULL CONSTRAINT push_message_pkey PRIMARY KEY,
-	device_registration_id INTEGER NOT NULL,
-	user_id VARCHAR(255) NOT NULL,
-	activation_id VARCHAR(37),
-	is_silent BOOLEAN DEFAULT false NOT NULL,
-	is_personal BOOLEAN DEFAULT false NOT NULL,
-	message_body VARCHAR(2048) NOT NULL,
-	timestamp_created TIMESTAMP(6) NOT NULL,
-	status INTEGER NOT NULL
-);
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::8::Lubos Racansky
+-- Create a new sequence push_device_registration
+CREATE TABLE push_device_registration (id INTEGER NOT NULL, activation_id VARCHAR(37), user_id VARCHAR(255), app_id INTEGER NOT NULL, platform VARCHAR(255) NOT NULL, push_token VARCHAR(255) NOT NULL, timestamp_last_registered TIMESTAMP(6) WITHOUT TIME ZONE NOT NULL, is_active BOOLEAN, CONSTRAINT push_device_registration_pkey PRIMARY KEY (id));
 
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::9::Lubos Racansky
+-- Create a new sequence push_message
+CREATE TABLE push_message (id INTEGER NOT NULL, device_registration_id INTEGER NOT NULL, user_id VARCHAR(255) NOT NULL, activation_id VARCHAR(37), is_silent BOOLEAN DEFAULT FALSE NOT NULL, is_personal BOOLEAN DEFAULT FALSE NOT NULL, message_body VARCHAR(2048) NOT NULL, timestamp_created TIMESTAMP(6) WITHOUT TIME ZONE NOT NULL, status INTEGER NOT NULL, CONSTRAINT push_message_pkey PRIMARY KEY (id));
 
--- Create table for push message campaigns
-CREATE TABLE push_campaign (
-	id INTEGER NOT NULL CONSTRAINT push_campaign_pkey PRIMARY KEY,
-	app_id INTEGER NOT NULL,
-	message VARCHAR(4000) NOT NULL,
-	is_sent BOOLEAN DEFAULT false NOT NULL,
-	timestamp_created TIMESTAMP(6) NOT NULL,
-	timestamp_sent TIMESTAMP(6),
-	timestamp_completed TIMESTAMP(6)
-);
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::10::Lubos Racansky
+-- Create a new sequence push_campaign
+CREATE TABLE push_campaign (id INTEGER NOT NULL, app_id INTEGER NOT NULL, message VARCHAR(4000) NOT NULL, is_sent BOOLEAN DEFAULT FALSE NOT NULL, timestamp_created TIMESTAMP(6) WITHOUT TIME ZONE NOT NULL, timestamp_sent TIMESTAMP(6) WITHOUT TIME ZONE, timestamp_completed TIMESTAMP(6) WITHOUT TIME ZONE, CONSTRAINT push_campaign_pkey PRIMARY KEY (id));
 
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::11::Lubos Racansky
+-- Create a new sequence push_campaign_user
+CREATE TABLE push_campaign_user (id INTEGER NOT NULL, campaign_id INTEGER NOT NULL, user_id VARCHAR(255) NOT NULL, timestamp_created TIMESTAMP(6) WITHOUT TIME ZONE NOT NULL, CONSTRAINT push_campaign_user_pkey PRIMARY KEY (id));
 
--- Create table for push campaign user list
-CREATE TABLE push_campaign_user (
-	id INTEGER NOT NULL CONSTRAINT push_campaign_user_pkey PRIMARY KEY,
-	campaign_id INTEGER NOT NULL,
-	user_id VARCHAR(255) NOT NULL,
-	timestamp_created TIMESTAMP(6) NOT NULL
-);
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::12::Lubos Racansky
+-- Create a new table push_inbox
+CREATE TABLE push_inbox (id INTEGER NOT NULL, inbox_id VARCHAR(37) NOT NULL, user_id VARCHAR(255) NOT NULL, type VARCHAR(32) NOT NULL, subject TEXT NOT NULL, summary TEXT NOT NULL, body TEXT NOT NULL, read BOOLEAN DEFAULT FALSE NOT NULL, timestamp_created TIMESTAMP WITHOUT TIME ZONE NOT NULL, timestamp_read TIMESTAMP WITHOUT TIME ZONE, CONSTRAINT push_inbox_pkey PRIMARY KEY (id));
 
--- Create table for message inbox
-CREATE TABLE push_inbox (
-    id INTEGER NOT NULL CONSTRAINT push_inbox_pk PRIMARY KEY,
-    inbox_id VARCHAR(37) NOT NULL,
-    user_id VARCHAR(255) NOT NULL,
-    type VARCHAR(32) NOT NULL,
-    subject TEXT NOT NULL,
-    summary TEXT NOT NULL,
-    body TEXT NOT NULL,
-    read BOOLEAN DEFAULT false NOT NULL,
-    timestamp_created TIMESTAMP NOT NULL,
-    timestamp_read TIMESTAMP
-);
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::13::Lubos Racansky
+-- Create a new sequence push_inbox_app
+CREATE TABLE push_inbox_app (app_credentials_id INTEGER NOT NULL, inbox_id INTEGER NOT NULL, CONSTRAINT push_inbox_app_pkey PRIMARY KEY (app_credentials_id, inbox_id));
 
--- Create table for assignment of inbox messages to apps
-CREATE TABLE push_inbox_app (
-    app_credentials_id INTEGER NOT NULL,
-    inbox_id           INTEGER NOT NULL,
-    CONSTRAINT push_inbox_app_pk PRIMARY KEY (inbox_id, app_credentials_id)
-);
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::14::Lubos Racansky
+-- Create a new unique index on push_app_credentials(app_id)
+CREATE UNIQUE INDEX push_app_cred_app ON push_app_credentials(app_id);
 
---
--- DB Indexes (recommended for better performance)
---
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::15::Lubos Racansky
+-- Create a new index on push_device_registration(app_id, push_token)
+CREATE INDEX push_device_app_token ON push_device_registration(app_id, push_token);
 
-CREATE UNIQUE INDEX push_app_cred_app ON push_app_credentials (app_id);
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::16::Lubos Racansky
+-- Create a new index on push_device_registration(user_id, app_id)
+CREATE INDEX push_device_user_app ON push_device_registration(user_id, app_id);
 
-CREATE INDEX push_device_app_token ON push_device_registration (app_id, push_token);
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::17::Lubos Racansky
+-- Create a new unique index on push_device_registration(activation_id)
+CREATE UNIQUE INDEX push_device_activation ON push_device_registration(activation_id);
 
-CREATE INDEX push_device_user_app ON push_device_registration (user_id, app_id);
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::18::Lubos Racansky
+-- Create a new unique index on push_device_registration(activation_id, push_token)
+CREATE UNIQUE INDEX push_device_activation_token ON push_device_registration(activation_id, push_token);
 
-CREATE UNIQUE INDEX push_device_activation ON push_device_registration (activation_id);
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::19::Lubos Racansky
+-- Create a new index on push_message(status)
+CREATE INDEX push_message_status ON push_message(status);
 
-CREATE UNIQUE INDEX push_device_activation_token ON push_device_registration (activation_id, push_token);
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::20::Lubos Racansky
+-- Create a new index on push_campaign(is_sent)
+CREATE INDEX push_campaign_sent ON push_campaign(is_sent);
 
-CREATE INDEX push_message_status ON push_message (status);
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::21::Lubos Racansky
+-- Create a new index on push_campaign_user(campaign_id, user_id)
+CREATE INDEX push_campaign_user_campaign ON push_campaign_user(campaign_id, user_id);
 
-CREATE INDEX push_campaign_sent ON push_campaign (is_sent);
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::22::Lubos Racansky
+-- Create a new index on push_campaign_user(user_id)
+CREATE INDEX push_campaign_user_detail ON push_campaign_user(user_id);
 
-CREATE INDEX push_campaign_user_campaign ON push_campaign_user (campaign_id, user_id);
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::23::Lubos Racansky
+-- Create a new index on push_inbox(inbox_id)
+CREATE INDEX push_inbox_id ON push_inbox(inbox_id);
 
-CREATE INDEX push_campaign_user_detail ON push_campaign_user (user_id);
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::24::Lubos Racansky
+-- Create a new index on push_inbox(user_id)
+CREATE INDEX push_inbox_user ON push_inbox(user_id);
 
-CREATE INDEX push_inbox_id ON push_inbox (inbox_id);
-CREATE INDEX push_inbox_user ON push_inbox (user_id);
-CREATE INDEX push_inbox_user_read ON push_inbox (user_id, read);
+-- Changeset powerauth-push-server/1.4.x/20230321-init-db.xml::25::Lubos Racansky
+-- Create a new index on push_inbox(user_id, read)
+CREATE INDEX push_inbox_user_read ON push_inbox(user_id, read);
+
+-- Changeset powerauth-push-server/1.4.x/20230322-add-tag-1.4.0.xml::1::Lubos Racansky
+-- Changeset powerauth-push-server/1.5.x/20230905-add-tag-1.5.0.xml::1::Lubos Racansky
+-- Changeset powerauth-push-server/1.7.x/20240119-push_app_credentials-hms.xml::1::Lubos Racansky
+-- Add hms_project_id, hms_client_id, and hms_client_secret columns to push_app_credentials
+ALTER TABLE push_app_credentials ADD hms_project_id VARCHAR(255);
+
+ALTER TABLE push_app_credentials ADD hms_client_id VARCHAR(255);
+
+ALTER TABLE push_app_credentials ADD hms_client_secret VARCHAR(255);
+
+COMMENT ON COLUMN push_app_credentials.hms_project_id IS 'Project ID defined in Huawei AppGallery Connect.';
+
+COMMENT ON COLUMN push_app_credentials.hms_client_id IS 'Huawei OAuth 2.0 Client ID.';
+
+COMMENT ON COLUMN push_app_credentials.hms_client_secret IS 'Huawei OAuth 2.0 Client Secret.';
+
+-- Changeset powerauth-push-server/1.7.x/20240222-add-tag-1.7.0.xml::1::Lubos Racansky

--- a/docs/sql/postgresql/migration_1.7.0_1.8.0.sql
+++ b/docs/sql/postgresql/migration_1.7.0_1.8.0.sql
@@ -1,0 +1,5 @@
+-- Changeset powerauth-push-server/1.8.x/20240708-column-renaming-keywords.xml::1::Roman Strobl
+-- Rename columns read to is_read and type to message_type in push_inbox table
+ALTER TABLE push_inbox RENAME COLUMN read TO is_read;
+
+ALTER TABLE push_inbox RENAME COLUMN type TO message_type;

--- a/powerauth-push-server/src/main/java/io/getlime/push/repository/InboxRepository.java
+++ b/powerauth-push-server/src/main/java/io/getlime/push/repository/InboxRepository.java
@@ -60,7 +60,7 @@ public interface InboxRepository extends PagingAndSortingRepository<InboxMessage
      */
     @Query("SELECT o FROM InboxMessageEntity o WHERE o.id IN (" +
             "SELECT DISTINCT o1.id FROM InboxMessageEntity o1 INNER JOIN o1.applications a " +
-            "WHERE o1.userId = :userId AND a.appId IN :applicationIds AND o1.read = :read" +
+            "WHERE o1.userId = :userId AND a.appId IN :applicationIds AND o1.isRead = :read" +
             ") ORDER BY o.timestampCreated DESC")
     List<InboxMessageEntity> findAllByUserIdAndApplicationsContainingAndReadOrderByTimestampCreatedDesc(String userId, List<String> applicationIds, boolean read, Pageable pageable);
 
@@ -75,10 +75,10 @@ public interface InboxRepository extends PagingAndSortingRepository<InboxMessage
      * Return how many there are records for given user ID with provided read state.
      * @param userId User ID.
      * @param app Application.
-     * @param read Read status.
+     * @param isRead Read status.
      * @return Count of messages for given user in provided read state.
      */
-    long countAllByUserIdAndApplicationsContainingAndRead(String userId, AppCredentialsEntity app, boolean read);
+    long countAllByUserIdAndApplicationsContainingAndIsRead(String userId, AppCredentialsEntity app, boolean isRead);
 
     /**
      * Mark all user messages as read.
@@ -87,7 +87,7 @@ public interface InboxRepository extends PagingAndSortingRepository<InboxMessage
      * @param date Date to which mark the messages as read.
      * @return Number of messages which were read.
      */
-    @Query("UPDATE InboxMessageEntity i SET i.read = true, i.timestampRead = :date WHERE i.userId = :userId AND :app MEMBER OF i.applications AND i.read = false")
+    @Query("UPDATE InboxMessageEntity i SET i.isRead = true, i.timestampRead = :date WHERE i.userId = :userId AND :app MEMBER OF i.applications AND i.isRead = false")
     @Modifying
     int markAllAsRead(String userId, AppCredentialsEntity app, Date date);
 

--- a/powerauth-push-server/src/main/java/io/getlime/push/repository/converter/InboxMessageConverter.java
+++ b/powerauth-push-server/src/main/java/io/getlime/push/repository/converter/InboxMessageConverter.java
@@ -56,7 +56,7 @@ public class InboxMessageConverter {
         destination.setInboxId(id.toString());
         destination.setUserId(userId);
         destination.setApplications(apps);
-        destination.setType(source.getType().getValue());
+        destination.setMessageType(source.getType().getValue());
         destination.setSubject(source.getSubject());
         destination.setSummary(source.getSummary());
         destination.setBody(source.getBody());
@@ -77,7 +77,7 @@ public class InboxMessageConverter {
         final GetInboxMessageDetailResponse destination = new GetInboxMessageDetailResponse();
         destination.setId(source.getInboxId());
         destination.setUserId(source.getUserId());
-        destination.setType(MessageType.fromLowerCaseString(source.getType()));
+        destination.setType(MessageType.fromLowerCaseString(source.getMessageType()));
         destination.setSubject(source.getSubject());
         destination.setSummary(source.getSummary());
         destination.setBody(source.getBody());
@@ -100,7 +100,7 @@ public class InboxMessageConverter {
         }
         final InboxMessage destination = new InboxMessage();
         destination.setId(source.getInboxId());
-        destination.setType(MessageType.fromLowerCaseString(source.getType()));
+        destination.setType(MessageType.fromLowerCaseString(source.getMessageType()));
         destination.setSubject(source.getSubject());
         destination.setSummary(source.getSummary());
         destination.setRead(source.isRead());

--- a/powerauth-push-server/src/main/java/io/getlime/push/repository/model/InboxMessageEntity.java
+++ b/powerauth-push-server/src/main/java/io/getlime/push/repository/model/InboxMessageEntity.java
@@ -76,8 +76,8 @@ public class InboxMessageEntity implements Serializable {
     /**
      * Message type.
      */
-    @Column(name = "`type`", nullable = false)
-    private String type;
+    @Column(name = "message_type", nullable = false)
+    private String messageType;
 
     /**
      * Message subject.
@@ -100,8 +100,8 @@ public class InboxMessageEntity implements Serializable {
     /**
      * Flag indicating if the message was read.
      */
-    @Column(name = "`read`")
-    private boolean read;
+    @Column(name = "is_read")
+    private boolean isRead;
 
     /**
      * Timestamp the message was created.
@@ -122,7 +122,7 @@ public class InboxMessageEntity implements Serializable {
         return inboxId.equals(that.inboxId)
                 && userId.equals(that.userId)
                 && applications.equals(that.applications)
-                && type.equals(that.type)
+                && messageType.equals(that.messageType)
                 && subject.equals(that.subject)
                 && summary.equals(that.summary)
                 && body.equals(that.body)
@@ -131,6 +131,6 @@ public class InboxMessageEntity implements Serializable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(inboxId, userId, applications, type, subject, summary, body, timestampCreated);
+        return Objects.hash(inboxId, userId, applications, messageType, subject, summary, body, timestampCreated);
     }
 }

--- a/powerauth-push-server/src/main/java/io/getlime/push/service/InboxService.java
+++ b/powerauth-push-server/src/main/java/io/getlime/push/service/InboxService.java
@@ -134,7 +134,7 @@ public class InboxService {
     @Transactional(readOnly=true)
     public GetInboxMessageCountResponse fetchMessageCountForUser(String userId, String appId) throws AppNotFoundException {
         final AppCredentialsEntity app = fetchAppForAppId(appId);
-        final long countUnread = inboxRepository.countAllByUserIdAndApplicationsContainingAndRead(userId, app,false);
+        final long countUnread = inboxRepository.countAllByUserIdAndApplicationsContainingAndIsRead(userId, app,false);
         return new GetInboxMessageCountResponse(countUnread);
     }
 


### PR DESCRIPTION
Due to problems with column name escaping in Oracle caused by enforced case sensitivity I had to rename the two columns which are problematic keywords in MSSQL.