### PR TITLE
Add CycloneDX Maven plugin version 2.9.1 for SBOM generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
         <google-api-client.version>2.7.2</google-api-client.version>
         <firebase-admin.version>9.3.0</firebase-admin.version>
         <logstash.version>8.1</logstash.version>
+        <cyclonedx-maven-plugin.version>2.9.1</cyclonedx-maven-plugin.version>
 
         <!-- Documentation Dependencies -->
         <springdoc-openapi-starter-webmvc-ui.version>2.8.8</springdoc-openapi-starter-webmvc-ui.version>
@@ -223,6 +224,12 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.cyclonedx</groupId>
+                <artifactId>cyclonedx-maven-plugin</artifactId>
+                <version>${cyclonedx-maven-plugin.version}</version>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
(cherry picked from commit a6758e43fb9f88143485d54b12f13d71f7b68ed2)