### PR TITLE
fixes #821 Optimize repository delete methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ rebel.xml
 
 # Compiled class files
 **/*.class
+
+# Copilot Instructions
+.github/copilot-instructions.md

--- a/powerauth-push-server/src/main/java/com/wultra/push/repository/PushCampaignUserRepository.java
+++ b/powerauth-push-server/src/main/java/com/wultra/push/repository/PushCampaignUserRepository.java
@@ -18,6 +18,8 @@ package com.wultra.push.repository;
 
 import com.wultra.push.repository.model.PushCampaignUserEntity;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.stereotype.Repository;
@@ -56,6 +58,8 @@ public interface PushCampaignUserRepository extends PagingAndSortingRepository<P
      * Delete all users who are associated with given campaign.
      * @param campaignId Campaign ID.
      */
+    @Modifying
+    @Query("DELETE FROM PushCampaignUserEntity u WHERE u.campaignId = ?1")
     void deleteByCampaignId(Long campaignId);
 
     /**
@@ -63,5 +67,7 @@ public interface PushCampaignUserRepository extends PagingAndSortingRepository<P
      * @param campaignId Campaign ID.
      * @param userId User ID.
      */
+    @Modifying
+    @Query("DELETE FROM PushCampaignUserEntity u WHERE u.campaignId = ?1 AND u.userId = ?2")
     void deleteByCampaignIdAndUserId(Long campaignId, String userId);
 }

--- a/powerauth-push-server/src/main/java/com/wultra/push/repository/PushDeviceRepository.java
+++ b/powerauth-push-server/src/main/java/com/wultra/push/repository/PushDeviceRepository.java
@@ -17,6 +17,8 @@
 package com.wultra.push.repository;
 
 import com.wultra.push.repository.model.PushDeviceRegistrationEntity;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
@@ -79,6 +81,8 @@ public interface PushDeviceRepository extends CrudRepository<PushDeviceRegistrat
      * @param rid Credentials database record ID.
      * @param pushToken Push Token.
      */
+    @Modifying
+    @Query("DELETE FROM PushDeviceRegistrationEntity d WHERE d.appCredentials.id = ?1 AND d.pushToken = ?2")
     void deleteAllByAppCredentialsIdAndPushToken(Long rid, String pushToken);
 
 }

--- a/powerauth-push-server/src/test/java/com/wultra/push/tests/PushRepositoryDeleteTest.java
+++ b/powerauth-push-server/src/test/java/com/wultra/push/tests/PushRepositoryDeleteTest.java
@@ -12,6 +12,7 @@ import com.wultra.push.repository.model.PushDeviceRegistrationEntity;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -48,13 +49,13 @@ class PushRepositoryDeleteTest {
         createCampaignUser(campaign.getId(), "user3");
         
         // Verify data exists
-        assertEquals(3, pushCampaignUserRepository.count());
+        assertEquals(3, pushCampaignUserRepository.findAllByCampaignId(campaign.getId(), Pageable.unpaged()).size());
         
         // Execute delete
         pushCampaignUserRepository.deleteByCampaignId(campaign.getId());
         
         // Verify deletion
-        assertEquals(0, pushCampaignUserRepository.count());
+        assertEquals(0, pushCampaignUserRepository.findAllByCampaignId(campaign.getId(), Pageable.unpaged()).size());
     }
 
     @Test
@@ -67,13 +68,13 @@ class PushRepositoryDeleteTest {
         createCampaignUser(campaign.getId(), "user2");
         
         // Verify data exists
-        assertEquals(2, pushCampaignUserRepository.count());
+        assertEquals(2, pushCampaignUserRepository.findAllByCampaignId(campaign.getId(), Pageable.unpaged()).size());
         
         // Execute delete for specific user
         pushCampaignUserRepository.deleteByCampaignIdAndUserId(campaign.getId(), "user1");
         
         // Verify deletion
-        assertEquals(1, pushCampaignUserRepository.count());
+        assertEquals(1, pushCampaignUserRepository.findAllByCampaignId(campaign.getId(), Pageable.unpaged()).size());
         assertNotNull(pushCampaignUserRepository.findFirstByUserIdAndCampaignId("user2", campaign.getId()));
         assertNull(pushCampaignUserRepository.findFirstByUserIdAndCampaignId("user1", campaign.getId()));
     }

--- a/powerauth-push-server/src/test/java/com/wultra/push/tests/PushRepositoryDeleteTest.java
+++ b/powerauth-push-server/src/test/java/com/wultra/push/tests/PushRepositoryDeleteTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.wultra.push.tests;
 
 import com.wultra.push.repository.AppCredentialsRepository;

--- a/powerauth-push-server/src/test/java/com/wultra/push/tests/PushRepositoryDeleteTest.java
+++ b/powerauth-push-server/src/test/java/com/wultra/push/tests/PushRepositoryDeleteTest.java
@@ -1,0 +1,138 @@
+package com.wultra.push.tests;
+
+import com.wultra.push.repository.AppCredentialsRepository;
+import com.wultra.push.repository.PushCampaignRepository;
+import com.wultra.push.repository.PushCampaignUserRepository;
+import com.wultra.push.repository.PushDeviceRepository;
+import com.wultra.push.repository.model.AppCredentialsEntity;
+import com.wultra.push.repository.model.Platform;
+import com.wultra.push.repository.model.PushCampaignEntity;
+import com.wultra.push.repository.model.PushCampaignUserEntity;
+import com.wultra.push.repository.model.PushDeviceRegistrationEntity;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Date;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class PushRepositoryDeleteTest {
+
+    @Autowired
+    private PushCampaignRepository pushCampaignRepository;
+
+    @Autowired
+    private PushCampaignUserRepository pushCampaignUserRepository;
+
+    @Autowired
+    private PushDeviceRepository pushDeviceRepository;
+
+    @Autowired
+    private AppCredentialsRepository appCredentialsRepository;
+
+    @Test
+    void testDeleteByCampaignId() {
+        // Prepare data
+        AppCredentialsEntity app = createAppCredentials("test_app_1");
+        PushCampaignEntity campaign = createCampaign(app);
+        
+        createCampaignUser(campaign.getId(), "user1");
+        createCampaignUser(campaign.getId(), "user2");
+        createCampaignUser(campaign.getId(), "user3");
+        
+        // Verify data exists
+        assertEquals(3, pushCampaignUserRepository.count());
+        
+        // Execute delete
+        pushCampaignUserRepository.deleteByCampaignId(campaign.getId());
+        
+        // Verify deletion
+        assertEquals(0, pushCampaignUserRepository.count());
+    }
+
+    @Test
+    void testDeleteByCampaignIdAndUserId() {
+        // Prepare data
+        AppCredentialsEntity app = createAppCredentials("test_app_2");
+        PushCampaignEntity campaign = createCampaign(app);
+        
+        createCampaignUser(campaign.getId(), "user1");
+        createCampaignUser(campaign.getId(), "user2");
+        
+        // Verify data exists
+        assertEquals(2, pushCampaignUserRepository.count());
+        
+        // Execute delete for specific user
+        pushCampaignUserRepository.deleteByCampaignIdAndUserId(campaign.getId(), "user1");
+        
+        // Verify deletion
+        assertEquals(1, pushCampaignUserRepository.count());
+        assertNotNull(pushCampaignUserRepository.findFirstByUserIdAndCampaignId("user2", campaign.getId()));
+        assertNull(pushCampaignUserRepository.findFirstByUserIdAndCampaignId("user1", campaign.getId()));
+    }
+
+    @Test
+    void testDeleteAllByAppCredentialsIdAndPushToken() {
+        // Prepare data
+        AppCredentialsEntity app = createAppCredentials("test_app_3");
+        String pushToken = "test_token_123";
+        
+        createDevice(app, pushToken, "user1");
+        createDevice(app, pushToken, "user2"); // Same token, different user (edge case)
+        
+        // Verify data exists
+        List<PushDeviceRegistrationEntity> devices = pushDeviceRepository.findByAppCredentialsAppIdAndPushToken(app.getAppId(), pushToken);
+        assertEquals(2, devices.size());
+        
+        // Execute delete
+        pushDeviceRepository.deleteAllByAppCredentialsIdAndPushToken(app.getId(), pushToken);
+        
+        // Verify deletion
+        List<PushDeviceRegistrationEntity> remainingDevices = pushDeviceRepository.findByAppCredentialsAppIdAndPushToken(app.getAppId(), pushToken);
+        assertEquals(0, remainingDevices.size());
+    }
+
+    // Helper methods
+    
+    private AppCredentialsEntity createAppCredentials(String appId) {
+        AppCredentialsEntity app = new AppCredentialsEntity();
+        app.setAppId(appId);
+        return appCredentialsRepository.save(app);
+    }
+
+    private PushCampaignEntity createCampaign(AppCredentialsEntity app) {
+        PushCampaignEntity campaign = new PushCampaignEntity();
+        campaign.setAppCredentials(app);
+        campaign.setMessage("Test message");
+        campaign.setSent(false);
+        campaign.setTimestampCreated(new Date());
+        return pushCampaignRepository.save(campaign);
+    }
+
+    private void createCampaignUser(Long campaignId, String userId) {
+        PushCampaignUserEntity user = new PushCampaignUserEntity();
+        user.setCampaignId(campaignId);
+        user.setUserId(userId);
+        user.setTimestampCreated(new Date());
+        pushCampaignUserRepository.save(user);
+    }
+
+    private void createDevice(AppCredentialsEntity app, String token, String userId) {
+        PushDeviceRegistrationEntity device = new PushDeviceRegistrationEntity();
+        device.setAppCredentials(app);
+        device.setPushToken(token);
+        device.setUserId(userId);
+        device.setActivationId("act_" + userId);
+        device.setTimestampLastRegistered(new Date());
+        device.setPlatform(Platform.APNS);
+        device.setActive(true);
+        pushDeviceRepository.save(device);
+    }
+}


### PR DESCRIPTION
This PR optimizes the performance of delete operations in `PushCampaignUserRepository` and `PushDeviceRepository` by replacing standard Spring Data JPA delete methods with direct JPQL queries.

**Changes:**
- Replaced `deleteByCampaignId` with a direct `DELETE FROM PushCampaignUserEntity` query.
- Replaced `deleteByCampaignIdAndUserId` with a direct `DELETE FROM PushCampaignUserEntity` query.
- Replaced `deleteAllByAppCredentialsIdAndPushToken` with a direct `DELETE FROM PushDeviceRegistrationEntity` query.
- Added `@Modifying` and `@Query` annotations to these methods to ensure efficient bulk deletion without fetching entities first.
- Added `PushRepositoryDeleteTest` to provide integration test coverage for these delete operations with real data.

**Issue:** #821