### PR TITLE
Fix #1103: JSON Logging Foundation

### DIFF
--- a/powerauth-push-server/docker/conf/logback/push-logback.xml
+++ b/powerauth-push-server/docker/conf/logback/push-logback.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <springProperty scope="context" name="appname" source="spring.application.name"/>
+    <springProperty scope="context" name="appname" source="spring.application.name" defaultValue="unknown"/>
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <includeMdc>true</includeMdc>

--- a/powerauth-push-server/docker/conf/logback/push-logback.xml
+++ b/powerauth-push-server/docker/conf/logback/push-logback.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
+    <springProperty scope="context" name="appname" source="spring.application.name"/>
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <includeMdc>true</includeMdc>
-            <customFields>{"appname":"powerauth-push-server"}</customFields>
+            <omitEmptyFields>true</omitEmptyFields>
+            <customFields>{"appname":"${appname}"}</customFields>
         </encoder>
     </appender>
 

--- a/powerauth-push-server/src/main/resources/application.properties
+++ b/powerauth-push-server/src/main/resources/application.properties
@@ -1,6 +1,8 @@
 # Allow externalization of properties using application-ext.properties
 spring.profiles.active=ext
 
+spring.application.name=powerauth-push-server
+
 # Database Configuration - PostgreSQL
 spring.datasource.url=${PUSH_SERVER_DATASOURCE_URL:jdbc:postgresql://localhost:5432/powerauth}
 spring.datasource.username=${PUSH_SERVER_DATASOURCE_USERNAME:powerauth}


### PR DESCRIPTION
## Summary

Fixes #1103 — JSON Logging Foundation for `powerauth-push-server`.

### Changes

- **L1**: Add `spring.application.name=powerauth-push-server` to `application.properties`
- **L3**: Replace hardcoded `appname` in `push-logback.xml` with `<springProperty>` sourced from `spring.application.name`
- **+**: Add `<omitEmptyFields>true</omitEmptyFields>` to suppress empty MDC fields from JSON output

### Affected files

- `powerauth-push-server/src/main/resources/application.properties`
- `powerauth-push-server/docker/conf/logback/push-logback.xml`

### Notes

- `logstash-logback-encoder` version `8.1` is already the latest — no version bump needed ✅

### References

- Issue: #1103
- Epic: wultra/tasklist#863 (JSON Logging Foundation)
- Logging Guideline: https://github.com/wultra/development-internal/wiki/Logging-Guideline

---

### Follow-up: defaultValue for springProperty

Added `defaultValue="unknown"` to `<springProperty>` in all logback configs.

`<springProperty>` is fully supported when the config is loaded via Spring Boot's Logback configurator (standard production path via `logging.config`). The `defaultValue` is a safety net for the edge case where the file is loaded as a plain Logback config outside of Spring Boot — in that scenario `spring.application.name` cannot be resolved and the fallback prevents `appname_IS_UNDEFINED` appearing in log output.