### PR TITLE
fix #1135: register lombok annotation processor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,19 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <excludedGroups>external-service</excludedGroups>


### PR DESCRIPTION
## Description

Registered Lombok as an explicit annotation processor in the root Maven compiler plugin configuration.

## Motivation and Context

Java 25 no longer enables implicit annotation processor discovery by default, so Lombok-generated members may be unavailable during compilation. Explicitly configuring Lombok in `annotationProcessorPaths` keeps local Java 25 builds working.

## Closes

Closes #1135